### PR TITLE
Fix import path and support go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/reviewdog/errorformat v0.0.0-20190922193611-a885a245ae0b
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20191104215741-3bf62ad25c68
-	gopkg.in/yaml.v2 v2.2.5 // indirect
+	gopkg.in/yaml.v2 v2.2.5
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/mattn/efm-langserver
+
+go 1.13
+
+require (
+	github.com/reviewdog/errorformat v0.0.0-20190922193611-a885a245ae0b
+	github.com/sourcegraph/jsonrpc2 v0.0.0-20191104215741-3bf62ad25c68
+	gopkg.in/yaml.v2 v2.2.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/haya14busa/go-checkstyle v0.0.0-20170303121022-5e9d09f51fa1/go.mod h1:RsN5RGgVYeXpcXNtWyztD5VIe7VNSEqpJvF2iEH7QvI=
+github.com/reviewdog/errorformat v0.0.0-20190922193611-a885a245ae0b h1:NABkU7TlpmdWxLPqjEDhFmsRolT7/d3hOPDj3LlnUmQ=
+github.com/reviewdog/errorformat v0.0.0-20190922193611-a885a245ae0b/go.mod h1:giYAXnpegRDPsXUO7TRpDKXJo1lFGYxyWRfEt5iQ+OA=
+github.com/sourcegraph/jsonrpc2 v0.0.0-20191104215741-3bf62ad25c68 h1:gFfGXdDReEGEn2ZtYfAFdhIZC6U54jfB+jVtFHk34o8=
+github.com/sourcegraph/jsonrpc2 v0.0.0-20191104215741-3bf62ad25c68/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
+gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/haya14busa/go-checkstyle v0.0.0-20170303121022-5e9d09f51fa1/go.mod h1:RsN5RGgVYeXpcXNtWyztD5VIe7VNSEqpJvF2iEH7QvI=
 github.com/reviewdog/errorformat v0.0.0-20190922193611-a885a245ae0b h1:NABkU7TlpmdWxLPqjEDhFmsRolT7/d3hOPDj3LlnUmQ=
 github.com/reviewdog/errorformat v0.0.0-20190922193611-a885a245ae0b/go.mod h1:giYAXnpegRDPsXUO7TRpDKXJo1lFGYxyWRfEt5iQ+OA=
 github.com/sourcegraph/jsonrpc2 v0.0.0-20191104215741-3bf62ad25c68 h1:gFfGXdDReEGEn2ZtYfAFdhIZC6U54jfB+jVtFHk34o8=
 github.com/sourcegraph/jsonrpc2 v0.0.0-20191104215741-3bf62ad25c68/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/haya14busa/errorformat"
+	"github.com/reviewdog/errorformat"
 	"github.com/sourcegraph/jsonrpc2"
 )
 


### PR DESCRIPTION
I wanted to instal this package with `go get`.
However, the following error occured:
```
$ go get github.com/mattn/efm-langserver
go: finding github.com/sourcegraph/jsonrpc2 latest
go: finding github.com/haya14busa/errorformat latest
go: github.com/mattn/efm-langserver imports
	github.com/mattn/efm-langserver/langserver imports
	github.com/haya14busa/errorformat: github.com/haya14busa/errorformat@v0.0.0-20190922193611-a885a245ae0b: parsing go.mod:
	module declares its path as: github.com/reviewdog/errorformat
	        but was required as: github.com/haya14busa/errorformat
```

It seems that `github.com/haya14busa/errorformat` has moved to `github.com/reviewdog/errorformat`.
I fixed that and add `go.mod` `go.sum`.