### PR TITLE
Format range should be based on input text

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -309,13 +309,13 @@ func (h *langHandler) formatFile(uri string) ([]TextEdit, error) {
 	}
 	h.logger.Println("format succeeded")
 	text := strings.Replace(string(b), "\r", "", -1)
-	lines := strings.Split(text, "\n")
+	flines := strings.Split(f.Text, "\n")
 
 	return []TextEdit{
 		{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: len(lines), Character: len(lines[len(lines)-1])},
+				End:   Position{Line: len(flines), Character: len(flines[len(flines)-1])},
 			},
 			NewText: text,
 		},


### PR DESCRIPTION
## Before:
With efm-langserver config:
```yaml
languages:
    json:
        format-command: 'jq .'
```

```json
{
  "a":
  "b",
  "c":
  "d"
}
```
is formated to
```json
{
  "a": "b",
  "c": "d"
}
}
```