### PR TITLE
Fix error handling after command execution

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -209,7 +209,7 @@ func (h *langHandler) lint(uri string) ([]Diagnostic, error) {
 			cmd.Stdin = strings.NewReader(f.Text)
 		}
 		b, err := cmd.CombinedOutput()
-		if err == nil && !config.LintIgnoreExitCode {
+		if err != nil && !config.LintIgnoreExitCode {
 			continue
 		}
 		for _, line := range strings.Split(string(b), "\n") {


### PR DESCRIPTION
Currently efm-langserver does not work at all in my environment.  It seems to have a small typo: the error handling after linter command execution seems opposite.  A linter should be ignored if:
- there is an error related to linter execution, (`err != nil`)
- and it's not specified to ignore the exit code. (`!LintIgnoreExitCode`)

Thank you for creating this fantastic software!