### PR TITLE
Add "prettier formatter" for html, css and json to example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ tools:
   php-phpstan: &php-phpstan
     lint-command: './vendor/bin/phpstan analyze --error-format raw --no-progress'
 
+  html-prettier: &html-prettier
+    format-command: './node_modules/.bin/prettier --parser html'
+
+  css-prettier: &css-prettier
+    format-command: './node_modules/.bin/prettier --parser css'
+
+  json-prettier: &json-prettier
+    format-command: './node_modules/.bin/prettier --parser json'
+
   json-jq: &json-jq
     lint-command: 'jq .'
 
@@ -102,9 +111,16 @@ languages:
   php:
     - <<: *php-phpstan
 
+  html:
+    - <<: *html-prettier
+
+  css:
+    - <<: *css-prettier
+
   json:
     - <<: *json-jq
     - <<: *json-fixjson
+    # - <<: *json-prettier
 
   csv:
     - <<: *csv-csvlint


### PR DESCRIPTION
Thanks for this plugin.

I added it `to REAME.md`.

Only the example of `json` using `prettier` was added with "comments out".