### PR TITLE
Doc: add more tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ tools:
       - '%f:%l %m'
       - '%f: %l: %m'
 
+  markdown-pandoc: &markdown-pandoc
+    format-command: 'pandoc -f markdown -t gfm -sp --tab-stop=2'
+
+  rst-pandoc: &rst-pandoc
+    format-command: 'pandoc -f rst -t rst -s --columns=79'
+
   yaml-yamllint: &yaml-yamllint
     lint-command: 'yamllint -f parsable -'
     lint-stdin: true
@@ -127,6 +133,10 @@ languages:
 
   markdown:
     - <<: *markdown-markdownlint
+    - <<: *markdown-pandoc
+
+  rst:
+    - <<: *rst-pandoc
 
   yaml:
     - <<: *yaml-yamllint

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ tools:
   rst-pandoc: &rst-pandoc
     format-command: 'pandoc -f rst -t rst -s --columns=79'
 
+  rst-lint: &rst-lint
+    lint-command: 'rst-lint'
+    lint-formats:
+      - '%tNFO %f:%l %m'
+      - '%tARNING %f:%l %m'
+      - '%tRROR %f:%l %m'
+      - '%tEVERE %f:%l %m'
+
   yaml-yamllint: &yaml-yamllint
     lint-command: 'yamllint -f parsable -'
     lint-stdin: true
@@ -136,6 +144,7 @@ languages:
     - <<: *markdown-pandoc
 
   rst:
+    - <<: *rst-lint
     - <<: *rst-pandoc
 
   yaml:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ tools:
       - '%f:%l:%c: %tarning: %m'
       - '%f:%l:%c: %tote: %m'
 
+  dockerfile-hadolint: &dockerfile-hadolint
+    lint-command: 'hadolint'
+    lint-formats:
+      - '%f:%l %m'
+
   sh-shellcheck: &sh-shellcheck
     lint-command: 'shellcheck -f gcc -x'
     lint-formats:
@@ -153,6 +158,9 @@ languages:
   python:
     - <<: *python-flake8
     - <<: *python-mypy
+
+  dockerfile:
+    - <<: *dockerfile-hadolint
 
   sh:
     - <<: *sh-shellcheck

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ tools:
       - '%f:%l:%c: %tarning: %m'
       - '%f:%l:%c: %tote: %m'
 
+  sh-shellcheck: &sh-shellcheck
+    lint-command: 'shellcheck -f gcc -x'
+    lint-formats:
+      - '%f:%l:%c: %trror: %m'
+      - '%f:%l:%c: %tarning: %m'
+      - '%f:%l:%c: %tote: %m'
+
+  sh-shfmt: &sh-shfmt
+    format-command: 'shfmt -ci -s -bn'
+
   javascript-eslint: &javascript-eslint
     lint-command: 'eslint -f unix --stdin'
     lint-ignore-exit-code: true
@@ -124,6 +134,10 @@ languages:
   python:
     - <<: *python-flake8
     - <<: *python-mypy
+
+  sh:
+    - <<: *sh-shellcheck
+    - <<: *sh-shfmt
 
   javascript:
     - <<: *javascript-eslint


### PR DESCRIPTION
Add the following tools to the example YAML config in the project README:

- ShellCheck: shell script linter
- shfmt: shell script formatter
- Pandoc: markdown and reStructuredText formatter
- restructuredtext-lint: reStructuredText linter
- hadolint: dockerfile linter