### PR TITLE
Fix: replace strings.Index with strings.Contains

### DIFF
--- a/langserver/handle_text_document_completion.go
+++ b/langserver/handle_text_document_completion.go
@@ -72,10 +72,10 @@ func (h *langHandler) completion(uri DocumentURI, params *CompletionParams) ([]C
 
 		command := config.CompletionCommand
 
-		if strings.Index(command, "${POSITION}") != -1 {
+		if strings.Contains(command, "${POSITION}") {
 			command = strings.Replace(command, "${POSITION}", fmt.Sprintf("%d:%d", params.TextDocumentPositionParams.Position.Line, params.Position.Character), -1)
 		}
-		if strings.Index(command, "${INPUT}") != -1 {
+		if strings.Contains(command, "${INPUT}") {
 			command = strings.Replace(command, "${INPUT}", fname, -1)
 		} else {
 			command = command + " " + "" + " " + fname

--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -68,7 +68,7 @@ func (h *langHandler) formatting(uri DocumentURI) ([]TextEdit, error) {
 		}
 
 		command := config.FormatCommand
-		if !config.FormatStdin && strings.Index(command, "${INPUT}") == -1 {
+		if !config.FormatStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
 		command = strings.Replace(command, "${INPUT}", fname, -1)

--- a/langserver/handle_text_document_hover.go
+++ b/langserver/handle_text_document_hover.go
@@ -102,7 +102,7 @@ func (h *langHandler) hover(uri DocumentURI, params *HoverParams) (*Hover, error
 		}
 
 		command := config.HoverCommand
-		if !config.HoverStdin && strings.Index(command, "${INPUT}") == -1 {
+		if !config.HoverStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
 		command = strings.Replace(command, "${INPUT}", word, -1)

--- a/langserver/handle_text_document_symbol.go
+++ b/langserver/handle_text_document_symbol.go
@@ -102,7 +102,7 @@ func (h *langHandler) symbol(uri DocumentURI) ([]SymbolInformation, error) {
 	symbols := []SymbolInformation{}
 	for _, config := range configs {
 		command := config.SymbolCommand
-		if !config.SymbolStdin && strings.Index(command, "${INPUT}") == -1 {
+		if !config.SymbolStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
 		command = strings.Replace(command, "${INPUT}", fname, -1)

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -215,7 +215,7 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 		}
 
 		command := config.LintCommand
-		if !config.LintStdin && strings.Index(command, "${INPUT}") == -1 {
+		if !config.LintStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
 		command = strings.Replace(command, "${INPUT}", fname, -1)


### PR DESCRIPTION
strings.Contains is the preferred way to check for the presence of a
substring. See https://staticcheck.io/docs/checks#S1003