### PR TITLE
Fix: format shfmt on stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ tools:
 
   sh-shfmt: &sh-shfmt
     format-command: 'shfmt -ci -s -bn'
+    format-stdin: true
 
   javascript-eslint: &javascript-eslint
     lint-command: 'eslint -f unix --stdin'


### PR DESCRIPTION
Prevent unsaved changes from being reverted on write by reading from
stdin instead of from disk.