### PR TITLE
Fix: check missed return values

### DIFF
--- a/langserver/handle_text_document_did_close.go
+++ b/langserver/handle_text_document_did_close.go
@@ -17,6 +17,8 @@ func (h *langHandler) handleTextDocumentDidClose(ctx context.Context, conn *json
 		return nil, err
 	}
 
-	h.closeFile(params.TextDocument.URI)
+	if err := h.closeFile(params.TextDocument.URI); err != nil {
+		return nil, err
+	}
 	return nil, nil
 }

--- a/langserver/handle_text_document_did_open.go
+++ b/langserver/handle_text_document_did_open.go
@@ -17,7 +17,9 @@ func (h *langHandler) handleTextDocumentDidOpen(ctx context.Context, conn *jsonr
 		return nil, err
 	}
 
-	h.openFile(params.TextDocument.URI, params.TextDocument.LanguageID)
+	if err := h.openFile(params.TextDocument.URI, params.TextDocument.LanguageID); err != nil {
+		return nil, err
+	}
 	if err := h.updateFile(params.TextDocument.URI, params.TextDocument.Text); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The return values of `h.openFile` and `h.closeFile` in
`handleTextDocumentDidOpen` and `handleTextDocumentDidClose` were
previously unchecked. This commit causes their errors to be returned if
they exist.