### PR TITLE
Make it possible to disable "go to definition" support

### DIFF
--- a/langserver/config.go
+++ b/langserver/config.go
@@ -15,8 +15,11 @@ func LoadConfig(yamlfile string) (*Config, error) {
 	}
 	defer f.Close()
 
-	var config Config
+	var config = Config{
+		ProvideDefinition: true, // Enabled by default.
+	}
 	var config1 Config1
+
 	err = yaml.NewDecoder(f).Decode(&config1)
 	if err != nil || config1.Version == 2 {
 		f, err = os.Open(yamlfile)

--- a/langserver/handle_initialize.go
+++ b/langserver/handle_initialize.go
@@ -38,8 +38,10 @@ func (h *langHandler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn,
 	if len(h.commands) > 0 {
 		hasCodeActionCommand = true
 	}
-	if _, err = exec.LookPath("ctags"); err == nil {
-		hasDefinitionCommand = true
+	if h.provideDefinition {
+		if _, err = exec.LookPath("ctags"); err == nil {
+			hasDefinitionCommand = true
+		}
 	}
 	for _, config := range h.configs {
 		for _, v := range config {

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -24,6 +24,9 @@ type Config struct {
 	Commands  []Command             `yaml:"commands"`
 	Languages map[string][]Language `yaml:"languages"`
 
+	// Toggle support for "go to definition" requests.
+	ProvideDefinition bool `yaml:"provide-definition"`
+
 	Filename string      `yaml:"-"`
 	Logger   *log.Logger `yaml:"-"`
 }
@@ -66,6 +69,7 @@ func NewHandler(config *Config) jsonrpc2.Handler {
 		logger:   config.Logger,
 		commands: config.Commands,
 		configs:  config.Languages,
+		provideDefinition: config.ProvideDefinition,
 		files:    make(map[DocumentURI]*File),
 		request:  make(chan DocumentURI),
 		conn:     nil,
@@ -76,16 +80,17 @@ func NewHandler(config *Config) jsonrpc2.Handler {
 }
 
 type langHandler struct {
-	loglevel int
-	logger   *log.Logger
-	commands []Command
-	configs  map[string][]Language
-	files    map[DocumentURI]*File
-	request  chan DocumentURI
-	conn     *jsonrpc2.Conn
-	rootPath string
-	filename string
-	folders  []string
+	loglevel          int
+	logger            *log.Logger
+	commands          []Command
+	configs           map[string][]Language
+	provideDefinition bool
+	files             map[DocumentURI]*File
+	request           chan DocumentURI
+	conn              *jsonrpc2.Conn
+	rootPath          string
+	filename          string
+	folders           []string
 }
 
 // File is


### PR DESCRIPTION
In my current setup, I'd like to disable the tags-based definition provider. Because the language-specific server (for example, `pyls`) handles definition requests, the results from `efm-langserver` create duplicates, and then `vim-lsp` prompts me to select which of two equivalent locations to jump to.

I don't know if this is the best way to implement the behavior toggle. I've added a top level config setting called `provide-definition`. If that is turned off, then on initialization `DefinitionProvider` is turned off. For backwards compatibility, the setting defaults to enabled.

Let me know what you think, and thank you for creating this useful tool.