### PR TITLE
Add Version to PublishDiagnosticsParams

### DIFF
--- a/langserver/handle_text_document_did_change.go
+++ b/langserver/handle_text_document_did_change.go
@@ -18,7 +18,7 @@ func (h *langHandler) handleTextDocumentDidChange(ctx context.Context, conn *jso
 	}
 
 	if len(params.ContentChanges) == 1 {
-		if err := h.updateFile(params.TextDocument.URI, params.ContentChanges[0].Text); err != nil {
+		if err := h.updateFile(params.TextDocument.URI, params.ContentChanges[0].Text, &params.TextDocument.Version); err != nil {
 			return nil, err
 		}
 	}

--- a/langserver/handle_text_document_did_open.go
+++ b/langserver/handle_text_document_did_open.go
@@ -17,10 +17,10 @@ func (h *langHandler) handleTextDocumentDidOpen(ctx context.Context, conn *jsonr
 		return nil, err
 	}
 
-	if err := h.openFile(params.TextDocument.URI, params.TextDocument.LanguageID); err != nil {
+	if err := h.openFile(params.TextDocument.URI, params.TextDocument.LanguageID, params.TextDocument.Version); err != nil {
 		return nil, err
 	}
-	if err := h.updateFile(params.TextDocument.URI, params.TextDocument.Text); err != nil {
+	if err := h.updateFile(params.TextDocument.URI, params.TextDocument.Text, &params.TextDocument.Version); err != nil {
 		return nil, err
 	}
 	return nil, nil

--- a/langserver/handle_text_document_did_save.go
+++ b/langserver/handle_text_document_did_save.go
@@ -18,7 +18,7 @@ func (h *langHandler) handleTextDocumentDidSave(ctx context.Context, conn *jsonr
 	}
 
 	if params.Text != nil {
-		err = h.updateFile(params.TextDocument.URI, *params.Text)
+		err = h.updateFile(params.TextDocument.URI, *params.Text, nil)
 	} else {
 		err = h.saveFile(params.TextDocument.URI)
 	}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -92,6 +92,7 @@ type langHandler struct {
 type File struct {
 	LanguageID string
 	Text       string
+	Version    int
 }
 
 func isWindowsDrivePath(path string) bool {
@@ -159,6 +160,7 @@ func (h *langHandler) linter() {
 			&PublishDiagnosticsParams{
 				URI:         uri,
 				Diagnostics: diagnostics,
+				Version:     h.files[uri].Version,
 			})
 	}
 }
@@ -316,21 +318,25 @@ func (h *langHandler) saveFile(uri DocumentURI) error {
 	return nil
 }
 
-func (h *langHandler) openFile(uri DocumentURI, languageID string) error {
+func (h *langHandler) openFile(uri DocumentURI, languageID string, version int) error {
 	f := &File{
 		Text:       "",
 		LanguageID: languageID,
+		Version:    version,
 	}
 	h.files[uri] = f
 	return nil
 }
 
-func (h *langHandler) updateFile(uri DocumentURI, text string) error {
+func (h *langHandler) updateFile(uri DocumentURI, text string, version *int) error {
 	f, ok := h.files[uri]
 	if !ok {
 		return fmt.Errorf("document not found: %v", uri)
 	}
 	f.Text = text
+	if version != nil {
+		f.Version = *version
+	}
 
 	h.request <- uri
 	return nil

--- a/langserver/lsp.go
+++ b/langserver/lsp.go
@@ -186,6 +186,7 @@ type Diagnostic struct {
 type PublishDiagnosticsParams struct {
 	URI         DocumentURI  `json:"uri"`
 	Diagnostics []Diagnostic `json:"diagnostics"`
+	Version     int          `json:"version"`
 }
 
 // FormattingOptions is


### PR DESCRIPTION
I implemented PublishDiagnosticsParams.version.

ref:
- https://microsoft.github.io/language-server-protocol/specification#textDocument_publishDiagnostics
- https://github.com/microsoft/language-server-protocol/issues/201

### motivation
This convenient for lsp client to handle diagnostics by multiple servers on the same language.

<details>
<summary>Example response</summary>

```go

type TestParams struct {
	a
}
```

gopls and golint respond the following against the above code.
Both responses include the same version.

```json
{
  "uri": "file:///home/notomo/workspace/efm-langserver/langserver/lsp.go",
  "diagnostics": [
    {
      "range": {
        "end": {
          "character": 2,
          "line": 185
        },
        "start": {
          "character": 1,
          "line": 185
        }
      },
      "source": "compiler",
      "message": "undeclared name: a",
      "severity": 1
    }
  ],
  "version": 50
}
{
  "uri": "file:///home/notomo/workspace/efm-langserver/langserver/lsp.go",
  "diagnostics": [
    {
      "range": {
        "end": {
          "character": 5,
          "line": 184
        },
        "start": {
          "character": 5,
          "line": 184
        }
      },
      "message": " exported type TestParams should have comment or be unexported",
      "severity": 1
    }
  ],
  "version": 50
}
```

</details>
