### PR TITLE
Add "lua-format" formatter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ tools:
   csv-csvlint: &csv-csvlint
     lint-command: 'csvlint'
 
+  lua-lua-format: &lua-lua-format
+    format-command: 'lua-format -i'
+    format-stdin: true
+
   any-excitetranslate: &any-excitetranslate
     hover-command: 'excitetranslate'
     hover-stdin: true
@@ -198,6 +202,9 @@ languages:
 
   csv:
     - <<: *csv-csvlint
+
+  lua:
+    - <<: *lua-lua-format
 
   _:
     - <<: *any-excitetranslate


### PR DESCRIPTION
### Description

Add "lua-format" formatter to README

### Tool

Binary download is recommended for easy installation of `lua-format`.

- Binary download
    - https://github.com/Koihik/vscode-lua-format/tree/master/bin
- GitHub
    - https://github.com/Koihik/LuaFormatter
- LuaRocks
    - https://luarocks.org/modules/tammela/luaformatter

### Demo

![efm-langserer-lua-format_960](https://user-images.githubusercontent.com/188642/88126949-984c4d80-cc0d-11ea-9791-41b43f4ba768.gif)
