### PR TITLE
Add blade-formatter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ tools:
     format-command: 'lua-format -i'
     format-stdin: true
 
+  blade-blade-formatter: &blade-blade-formatter
+    format-command: 'blade-formatter --stdin'
+    format-stdin: true
+
   any-excitetranslate: &any-excitetranslate
     hover-command: 'excitetranslate'
     hover-stdin: true
@@ -205,6 +209,9 @@ languages:
 
   lua:
     - <<: *lua-lua-format
+
+  blade:
+    - <<: *blade-blade-formatter
 
   _:
     - <<: *any-excitetranslate


### PR DESCRIPTION
### Description

Laravel (PHP Web Framework) has a template file called `blade`.
Add blade-formatter to README.

### Tool

- GitHub
    - https://github.com/shufo/blade-formatter
- npm
    - https://www.npmjs.com/package/blade-formatter

### Other (recommended plugin)

- **vim-blade**: blade syntax and filetype plugin
    - https://github.com/jwalton512/vim-blade

### DEMO

![efm-blade-formatter-1200](https://user-images.githubusercontent.com/188642/89741150-d4b2f100-dac9-11ea-8381-288edd8e772c.gif)
