### PR TITLE
doc: schema: add command os description and type define

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -18,6 +18,10 @@
             "description": "command to execute",
             "type": "string"
           },
+          "os": {
+            "description": "command executable OS environment",
+            "type": "string"
+          },
           "title": {
             "description": "title for clients",
             "type": "string"


### PR DESCRIPTION
When if schema lost `commands comamand os` vocabulary. This  PR is adding.

If it does not match, it will be closing.