### PR TITLE
Add FormatIgnoreStderr option

### DIFF
--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -86,7 +86,7 @@ func (h *langHandler) formatting(uri DocumentURI) ([]TextEdit, error) {
 		if config.FormatStdin {
 			cmd.Stdin = strings.NewReader(text)
 		}
-		b, err := cmd.CombinedOutput()
+		b, err := cmd.Output()
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Some formatter like `black` print information to stderr (`All done! ✨ 🍰 ✨ 1 file reformatted.`)
This adds an option to ignore stderr output and only use stdout