### PR TITLE
Fix lowest severity character

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -418,7 +418,7 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 				severity = 2
 			case entry.Type == 'I' || entry.Type == 'i':
 				severity = 3
-			case entry.Type == 'H' || entry.Type == 'h':
+			case entry.Type == 'N' || entry.Type == 'n':
 				severity = 4
 			}
 			diagnostics = append(diagnostics, Diagnostic{


### PR DESCRIPTION
According to https://vim-jp.org/vimdoc-en/quickfix.html#error-file-format, the lowest severity is note, not hint, which the code seems to check for.

I stumbled on this when migrating from diagnostic-languageserver, and saw that my shellcheck hints turned to errors.