### PR TITLE
Add support for FormattingOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ tools:
       - '%f:%l:%c:%tarning - %m'
 
   html-prettier: &html-prettier
-    format-command: './node_modules/.bin/prettier --parser html'
+    format-command: './node_modules/.bin/prettier ${--tab-width:tabWidth} ${--single-quote:singleQuote} --parser html'
 
   css-prettier: &css-prettier
-    format-command: './node_modules/.bin/prettier --parser css'
+    format-command: './node_modules/.bin/prettier ${--tab-width:tabWidth} ${--single-quote:singleQuote} --parser css'
 
   json-prettier: &json-prettier
-    format-command: './node_modules/.bin/prettier --parser json'
+    format-command: './node_modules/.bin/prettier ${--tab-width:tabWidth} --parser json'
 
   json-jq: &json-jq
     lint-command: 'jq .'

--- a/langserver/lsp.go
+++ b/langserver/lsp.go
@@ -190,10 +190,7 @@ type PublishDiagnosticsParams struct {
 }
 
 // FormattingOptions is
-type FormattingOptions struct {
-	TabSize      int64 `json:"tabSize"`
-	InsertSpaces bool  `json:"insertSpaces"`
-}
+type FormattingOptions map[string]interface{}
 
 // DocumentFormattingParams is
 type DocumentFormattingParams struct {


### PR DESCRIPTION
With this PR `format-command` can specify placeholder that get filled in by `FormattingOptions` passed in from the client.
LSP spec: https://microsoft.github.io/language-server-protocol/specification.html#textDocument_formatting

The syntax looks like `${--cmd-line-flag:optionName}`

If the option is not supplied from the client, the placeholder will be removed.

Options support string, int and boolean values.
String and int values will resolve to `--cmd-line-flag value`.
Boolean values will resolve to `--cmd-line-flag`

Client then can call formatting with options like `{ "tabWidth": 4, "singleQute": true }`