### PR TITLE
Quiet flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Usage of efm-langserver:
         logfile
   -loglevel int
         loglevel (default 1)
+  -q    Run quieter
   -v    Print the version
 ```
 

--- a/main.go
+++ b/main.go
@@ -73,9 +73,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !quiet {
-		log.Println("efm-langserver: reading on stdin, writing on stdout")
+	if quiet {
+		log.SetOutput(ioutil.Discard)
 	}
+
+	log.Println("efm-langserver: reading on stdin, writing on stdout")
 
 	if logfile == "" {
 		logfile = config.LogFile
@@ -108,9 +110,7 @@ func main() {
 		jsonrpc2.NewBufferedStream(stdrwc{}, jsonrpc2.VSCodeObjectCodec{}),
 		handler, connOpt...).DisconnectNotify()
 
-	if !quiet {
-		log.Println("efm-langserver: connections closed")
-	}
+	log.Println("efm-langserver: connections closed")
 }
 
 type stdrwc struct{}

--- a/main.go
+++ b/main.go
@@ -26,12 +26,14 @@ func main() {
 	var loglevel int
 	var dump bool
 	var showVersion bool
+	var quiet bool
 
 	flag.StringVar(&yamlfile, "c", "", "path to config.yaml")
 	flag.StringVar(&logfile, "logfile", "", "logfile")
 	flag.IntVar(&loglevel, "loglevel", 1, "loglevel")
 	flag.BoolVar(&dump, "d", false, "dump configuration")
 	flag.BoolVar(&showVersion, "v", false, "Print the version")
+	flag.BoolVar(&quiet, "q", false, "Run quieter")
 	flag.Parse()
 
 	if showVersion {
@@ -69,7 +71,10 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	log.Println("efm-langserver: reading on stdin, writing on stdout")
+
+	if !quiet {
+		log.Println("efm-langserver: reading on stdin, writing on stdout")
+	}
 
 	if logfile == "" {
 		logfile = config.LogFile
@@ -97,7 +102,10 @@ func main() {
 		context.Background(),
 		jsonrpc2.NewBufferedStream(stdrwc{}, jsonrpc2.VSCodeObjectCodec{}),
 		handler, connOpt...).DisconnectNotify()
-	log.Println("efm-langserver: connections closed")
+
+	if !quiet {
+		log.Println("efm-langserver: connections closed")
+	}
 }
 
 type stdrwc struct{}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -95,6 +96,10 @@ func main() {
 		if loglevel >= 5 {
 			connOpt = append(connOpt, jsonrpc2.LogMessages(config.Logger))
 		}
+	}
+
+	if quiet && (logfile == "" || loglevel < 5) {
+		connOpt = append(connOpt, jsonrpc2.LogMessages(log.New(ioutil.Discard, "", 0)))
 	}
 
 	handler := langserver.NewHandler(config)


### PR DESCRIPTION
When running the server with Neovim, Neovim's log fills up slowly with stderr output from efm-langserver, mostly the examples below:

```
2020/11/18 08:17:55 efm-langserver: reading on stdin, writing on stdout
2020/11/18 08:37:27 jsonrpc2 handler: notification "exit" handling error: jsonrpc2: code -32601 message: method not supported: exit
```

This adds a command line flag `-q` that disables those stderr logs. The logging to file built in to efm-langserver is not affected by the quiet flag.