### PR TITLE
Updates README with working `mix credo` linter usage example for elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ tools:
     format-command: 'blade-formatter --stdin'
     format-stdin: true
 
+  mix_credo: &mix_credo
+    lint-command: "mix credo suggest --format=flycheck --read-from-stdin ${INPUT}"
+    lint-stdin: true
+    lint-ignore-exit-code: true
+    lint-formats:
+      - '%f:%l:%c: %m'
+    root-markers:
+      - mix.lock
+      - mix.exs
+
   any-excitetranslate: &any-excitetranslate
     hover-command: 'excitetranslate'
     hover-stdin: true
@@ -215,6 +225,9 @@ languages:
 
   blade:
     - <<: *blade-blade-formatter
+
+  elixir:
+    - <<: *mix_credo
 
   _:
     - <<: *any-excitetranslate


### PR DESCRIPTION
From an issue/discussion here: https://github.com/mattn/efm-langserver/issues/62#issuecomment-729707136