### PR TITLE
Add support for DidChangeConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,36 @@ Usage of efm-langserver:
   -v    Print the version
 ```
 
+### Configuration
+
+Configuration can be done with either a `config.yaml` file, or through
+a [DidChangeConfiguration](https://microsoft.github.io/language-server-protocol/specification.html#workspace_didChangeConfiguration)
+notification from the client.
+`DidChangeConfiguration` can be called any time and will overwrite only provided
+properties.
+
+`DidChangeConfiguration` only supports V2 configuration and cannot set `LogFile`.
+
+
+#### InitializeParams
+
+Because the configuration can be updated on the fly, capabilities might change
+throughout the lifetime of the server. To enable support for capabilities that will
+be available later, set them in the [InitializeParams](https://microsoft.github.io/language-server-protocol/specification.html#initialize)
+
+Example
+```json
+{
+    "initializationOptions": {
+        "documentFormatting": true,
+        "hover": true,
+        "documentSymbol": true,
+        "codeAction": true,
+        "completion": true
+    }
+}
+```
+
 ### Example for config.yaml
 
 Location of config.yaml is:
@@ -228,6 +258,22 @@ log-file: /path/to/output.log
 log-level: 1
 ```
 
+### Example for DidChangeConfiguration notification
+
+```json
+{
+    "settings": {
+        "rootMarkers": [".git/"],
+        "languages": {
+            "lua": {
+                "formatCommand": "lua-format -i",
+                "formatStdin": true
+            }
+        }
+    }
+}
+```
+
 ### Configuration for [vim-lsp](https://github.com/prabirshrestha/vim-lsp/)
 
 ```vim
@@ -268,6 +314,26 @@ Add to eglot-server-programs with major mode you want.
 (with-eval-after-load 'eglot
   (add-to-list 'eglot-server-programs
     `(markdown-mode . ("efm-langserver"))))
+```
+
+### Configuration for [neovim buildin LSP](https://neovim.io/doc/user/lsp.html) with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
+
+init.vim
+
+```vim
+lua << EOF
+require "lspconfig".efm.setup {
+    init_options = {documentFormatting = true},
+    settings = {
+        rootMarkers = {".git/"},
+        languages = {
+            lua = {
+                {formatCommand = "lua-format -i", formatStdin = true}
+            }
+        }
+    }
+}
+EOF
 ```
 
 ## Supported Lint tools

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -2,6 +2,7 @@ package langserver
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -9,16 +10,20 @@ import (
 
 // LoadConfig load configuration from file
 func LoadConfig(yamlfile string) (*Config, error) {
-	f, err := os.Open(yamlfile)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
 	var config = Config{
 		ProvideDefinition: true, // Enabled by default.
+		Commands:          &[]Command{},
+		Languages:         &map[string][]Language{},
+		RootMarkers:       &[]string{},
 	}
 	var config1 Config1
+
+	f, err := os.Open(yamlfile)
+	if err != nil {
+		log.Println("efm-langserver: no configuration file")
+		return &config, nil
+	}
+	defer f.Close()
 
 	err = yaml.NewDecoder(f).Decode(&config1)
 	if err != nil || config1.Version == 2 {
@@ -33,13 +38,13 @@ func LoadConfig(yamlfile string) (*Config, error) {
 		}
 	} else {
 		config.Version = config1.Version
-		config.Commands = config1.Commands
+		config.Commands = &config1.Commands
 		config.Logger = config1.Logger
 		languages := make(map[string][]Language)
 		for k, v := range config1.Languages {
 			languages[k] = []Language{v}
 		}
-		config.Languages = languages
+		config.Languages = &languages
 	}
 	config.Filename = yamlfile
 	return &config, nil

--- a/langserver/handle_initialize.go
+++ b/langserver/handle_initialize.go
@@ -29,10 +29,11 @@ func (h *langHandler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn,
 	h.addFolder(rootPath)
 
 	var completion *CompletionProvider
-	var hasHoverCommand bool
-	var hasCodeActionCommand bool
-	var hasSymbolCommand bool
-	var hasFormatCommand bool
+	var hasCompletionCommand bool = params.InitializationOptions.Completion
+	var hasHoverCommand bool = params.InitializationOptions.Hover
+	var hasCodeActionCommand bool = params.InitializationOptions.CodeAction
+	var hasSymbolCommand bool = params.InitializationOptions.DocumentSymbol
+	var hasFormatCommand bool = params.InitializationOptions.DocumentFormatting
 	var hasDefinitionCommand bool
 
 	if len(h.commands) > 0 {
@@ -46,9 +47,7 @@ func (h *langHandler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn,
 	for _, config := range h.configs {
 		for _, v := range config {
 			if v.CompletionCommand != "" {
-				completion = &CompletionProvider{
-					TriggerCharacters: []string{"*"},
-				}
+				hasCompletionCommand = true
 			}
 			if v.HoverCommand != "" {
 				hasHoverCommand = true
@@ -59,6 +58,12 @@ func (h *langHandler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn,
 			if v.FormatCommand != "" {
 				hasFormatCommand = true
 			}
+		}
+	}
+
+	if hasCompletionCommand {
+		completion = &CompletionProvider{
+			TriggerCharacters: []string{"*"},
 		}
 	}
 

--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -139,8 +139,11 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (interface{},
 			if err != nil {
 				return nil, err
 			}
-			h.commands = config.Commands
-			h.configs = config.Languages
+			h.commands = *config.Commands
+			h.configs = *config.Languages
+			h.rootMarkers = *config.RootMarkers
+			h.loglevel = config.LogLevel
+			h.lintDebounce = config.LintDebounce
 		}
 		h.logMessage(LogInfo, "Reloaded configuration file")
 		output = "OK"

--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -91,7 +91,9 @@ Configs:
 			default:
 				command = re.ReplaceAllString(command, fmt.Sprintf("$1 %v", v))
 			case bool:
-				command = re.ReplaceAllString(command, "$1")
+				if v {
+					command = re.ReplaceAllString(command, "$1")
+				}
 			}
 		}
 		re := regexp.MustCompile(`\${[^}]*}`)

--- a/langserver/handle_workspace_did_change_configuration.go
+++ b/langserver/handle_workspace_did_change_configuration.go
@@ -17,9 +17,25 @@ func (h *langHandler) handleWorkspaceDidChangeConfiguration(ctx context.Context,
 		return nil, err
 	}
 
-	return h.didChangeConfiguration(&params)
+	return h.didChangeConfiguration(&params.Settings)
 }
 
-func (h *langHandler) didChangeConfiguration(params *DidChangeConfigurationParams) (interface{}, error) {
+func (h *langHandler) didChangeConfiguration(config *Config) (interface{}, error) {
+	if config.Languages != nil {
+		h.configs = *config.Languages
+	}
+	if config.RootMarkers != nil {
+		h.rootMarkers = *config.RootMarkers
+	}
+	if config.Commands != nil {
+		h.commands = *config.Commands
+	}
+	if config.LogLevel > 0 {
+		h.loglevel = config.LogLevel
+	}
+	if config.LintDebounce > 0 {
+		h.lintDebounce = config.LintDebounce
+	}
+
 	return nil, nil
 }

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -24,13 +24,13 @@ import (
 
 // Config is
 type Config struct {
-	Version      int                   `yaml:"version"`
-	LogFile      string                `yaml:"log-file"`
-	LogLevel     int                   `yaml:"log-level"`
-	Commands     []Command             `yaml:"commands"`
-	Languages    map[string][]Language `yaml:"languages"`
-	RootMarkers  []string              `yaml:"root-markers"`
-	LintDebounce time.Duration         `yaml:"lint-debounce"`
+	Version      int                    `yaml:"version"`
+	LogFile      string                 `yaml:"log-file"`
+	LogLevel     int                    `yaml:"log-level" json:"logLevel"`
+	Commands     *[]Command             `yaml:"commands" json:"commands"`
+	Languages    *map[string][]Language `yaml:"languages" json:"languages"`
+	RootMarkers  *[]string              `yaml:"root-markers" json:"rootMarkers"`
+	LintDebounce time.Duration          `yaml:"lint-debounce" json:"lintDebounce"`
 
 	// Toggle support for "go to definition" requests.
 	ProvideDefinition bool `yaml:"provide-definition"`
@@ -49,24 +49,24 @@ type Config1 struct {
 
 // Language is
 type Language struct {
-	LintFormats        []string  `yaml:"lint-formats"`
-	LintStdin          bool      `yaml:"lint-stdin"`
-	LintOffset         int       `yaml:"lint-offset"`
-	LintCommand        string    `yaml:"lint-command"`
-	LintIgnoreExitCode bool      `yaml:"lint-ignore-exit-code"`
-	FormatCommand      string    `yaml:"format-command"`
-	FormatStdin        bool      `yaml:"format-stdin"`
-	SymbolCommand      string    `yaml:"symbol-command"`
-	SymbolStdin        bool      `yaml:"symbol-stdin"`
-	SymbolFormats      []string  `yaml:"symbol-formats"`
-	CompletionCommand  string    `yaml:"completion-command"`
-	CompletionStdin    bool      `yaml:"completion-stdin"`
-	HoverCommand       string    `yaml:"hover-command"`
-	HoverStdin         bool      `yaml:"hover-stdin"`
-	HoverType          string    `yaml:"hover-type"`
-	Env                []string  `yaml:"env"`
-	RootMarkers        []string  `yaml:"root-markers"`
-	Commands           []Command `yaml:"commands"`
+	LintFormats        []string  `yaml:"lint-formats" json:"lintFormats"`
+	LintStdin          bool      `yaml:"lint-stdin" json:"lintStdin"`
+	LintOffset         int       `yaml:"lint-offset" json:"lintOffset"`
+	LintCommand        string    `yaml:"lint-command" json:"lintCommand"`
+	LintIgnoreExitCode bool      `yaml:"lint-ignore-exit-code" json:"lintIgnoreExitCode"`
+	FormatCommand      string    `yaml:"format-command" json:"formatCommand"`
+	FormatStdin        bool      `yaml:"format-stdin" json:"formatStdin"`
+	SymbolCommand      string    `yaml:"symbol-command" json:"symbolCommand"`
+	SymbolStdin        bool      `yaml:"symbol-stdin" json:"symbolStdin"`
+	SymbolFormats      []string  `yaml:"symbol-formats" json:"symbolFormats"`
+	CompletionCommand  string    `yaml:"completion-command" json:"completionCommand"`
+	CompletionStdin    bool      `yaml:"completion-stdin" json:"completionStdin"`
+	HoverCommand       string    `yaml:"hover-command" json:"hoverCommand"`
+	HoverStdin         bool      `yaml:"hover-stdin" json:"hoverStdin"`
+	HoverType          string    `yaml:"hover-type" json:"hoverType"`
+	Env                []string  `yaml:"env" json:"env"`
+	RootMarkers        []string  `yaml:"root-markers" json:"rootMarkers"`
+	Commands           []Command `yaml:"commands" json:"commands"`
 }
 
 // NewHandler create JSON-RPC handler for this language server.
@@ -74,11 +74,12 @@ func NewHandler(config *Config) jsonrpc2.Handler {
 	if config.Logger == nil {
 		config.Logger = log.New(os.Stderr, "", log.LstdFlags)
 	}
+
 	var handler = &langHandler{
 		loglevel:          config.LogLevel,
 		logger:            config.Logger,
-		commands:          config.Commands,
-		configs:           config.Languages,
+		commands:          *config.Commands,
+		configs:           *config.Languages,
 		provideDefinition: config.ProvideDefinition,
 		files:             make(map[DocumentURI]*File),
 		request:           make(chan DocumentURI),
@@ -86,7 +87,7 @@ func NewHandler(config *Config) jsonrpc2.Handler {
 		lintTimer:         nil,
 		conn:              nil,
 		filename:          config.Filename,
-		rootMarkers:       config.RootMarkers,
+		rootMarkers:       *config.RootMarkers,
 	}
 	go handler.linter()
 	return jsonrpc2.HandlerWithError(handler.handle)

--- a/langserver/lsp.go
+++ b/langserver/lsp.go
@@ -16,6 +16,11 @@ type InitializeParams struct {
 
 // InitializeOptions is
 type InitializeOptions struct {
+	DocumentFormatting bool `json:"documentFormatting"`
+	Hover              bool `json:"hover"`
+	DocumentSymbol     bool `json:"documentSymbol"`
+	CodeAction         bool `json:"codeAction"`
+	Completion         bool `json:"completion"`
 }
 
 // ClientCapabilities is
@@ -383,7 +388,7 @@ type CodeActionParams struct {
 
 // DidChangeConfigurationParams is
 type DidChangeConfigurationParams struct {
-	Settings interface{} `json:"settings"`
+	Settings Config `json:"settings"`
 }
 
 // NotificationMessage is

--- a/main.go
+++ b/main.go
@@ -53,6 +53,11 @@ func main() {
 			log.Fatal(err)
 		}
 		yamlfile = filepath.Join(dir, "config.yaml")
+	} else {
+		_, err := os.Stat(yamlfile)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	config, err := langserver.LoadConfig(yamlfile)


### PR DESCRIPTION
This allows the client to change the configuration on the fly.
As well as replace the need for a config file.

Clients send a `DidChangeConfiguration` notification to update the
configuration. Only supplied values will be overwritten.
Supported values are:
  1. `Languages`
  2. `RootMarkers`
  3. `Commands`
  4. `LogLevel`
  5. `LintDebounce`

In addition, because the capabilities are now dynamic, The client can
specify the server capabilities on initialization with
`InitializeParams`.
Supported values are:
  1. `Completion`
  2. `Hover`
  3. `CodeAction`
  4. `DocumentSymbol`
  5. `DocumentFormatting`

config file can still be used as before. `DidChangeConfiguration` only overwrites provided properties.

LSP spec:
https://microsoft.github.io/language-server-protocol/specification.html#workspace_didChangeConfiguration
https://microsoft.github.io/language-server-protocol/specification.html#initialize