### PR TITLE
feat: Update schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -61,10 +61,11 @@
         },
         "env": {
           "description": "command environment variables and values",
-          "type": "string",
-          "patternProperties": {
-            "^[a-zA-Z0-9._-]+=[a-zA-Z0-9._-]+$": {}
-          }
+          "items": {
+            "type": "string",
+            "pattern": "^.+=.+$"
+          },
+          "type": "array"
         },
         "lint-command": {
           "description": "lint command",

--- a/schema.json
+++ b/schema.json
@@ -51,6 +51,21 @@
           "description": "use stdin for the hover",
           "type": "boolean"
         },
+        "hover-type": {
+          "description": "hover result type",
+          "type": "string",
+          "enum": [
+            "markdown",
+            "plaintext"
+          ]
+        },
+        "env": {
+          "description": "command environment variables and values",
+          "type": "string",
+          "patternProperties": {
+            "^[a-zA-Z0-9._-]+=[a-zA-Z0-9._-]+$": {}
+          }
+        },
         "lint-command": {
           "description": "lint command",
           "type": "string"


### PR DESCRIPTION
- support hover-type enum (select `markdown` or `plaintext`)
- support env string array (validate `any=any`)