### PR TITLE
small fix - schema log-level

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -159,6 +159,7 @@
     },
     "log-level": {
       "description": "log level",
+      "minimum": 1,
       "type": "number"
     },
     "lint-debounce": {


### PR DESCRIPTION
set minimum 1 (include)

----

log level max defined?
If do so, fix together.

And other repair point remain?
(I think, stdin default value...)