### PR TITLE
Prevent multiple linters running for the same URI

### DIFF
--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -1,6 +1,7 @@
 package langserver
 
 import (
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ func TestLintNoLinter(t *testing.T) {
 		},
 	}
 
-	_, err := h.lint("file:///foo")
+	_, err := h.lint(context.Background(), "file:///foo")
 	if err != nil {
 		t.Fatal("Should not be an error if no linters")
 	}
@@ -32,7 +33,7 @@ func TestLintNoFileMatched(t *testing.T) {
 		},
 	}
 
-	_, err := h.lint("file:///bar")
+	_, err := h.lint(context.Background(), "file:///bar")
 	if err == nil {
 		t.Fatal("Should be an error if no linters")
 	}
@@ -63,7 +64,7 @@ func TestLintFileMatched(t *testing.T) {
 		},
 	}
 
-	d, err := h.lint(uri)
+	d, err := h.lint(context.Background(), uri)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +110,7 @@ func TestLintFileMatchedForce(t *testing.T) {
 		},
 	}
 
-	d, err := h.lint(uri)
+	d, err := h.lint(context.Background(), uri)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I ran into an issue while running eslint on a rather large file using eslint via efm-langserver. My setup sends diagnostics requests to the langserver whenever a change is done, and eslint takes around 4s for the largish file. With the current release of efm-langserver, this means that diagnostics requests are backed up, and requests are processed in sequence, allowing the linter to finish before processing the next request. This means that for example 3 lint requests would take 12 seconds and any diagnostics requests coming in during that time would add another 4 seconds to that.

This change spawns each linter in its own goroutine, and using `context.Context` a running request for a specific URI is canceled if a new request for linting arrives.

Hopefully my description makes sense!