### PR TITLE
Add various python formatters to REAMDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ tools:
       - '%f:%l:%c: %tarning: %m'
       - '%f:%l:%c: %tote: %m'
 
+  python-black: &python-black
+    format-command: 'black --quiet -'
+    format-stdin: true
+
+  python-autopep8: &python-autopep8
+    format-command: 'autopep8 -'
+    format-stdin: true
+
+  python-yapf: &python-yapf
+    format-command: 'yapf --quiet'
+    format-stdin: true
+
+  python-isort: &python-isort
+    format-command: 'isort --quiet -'
+    format-stdin: true
+
   dockerfile-hadolint: &dockerfile-hadolint
     lint-command: 'hadolint'
     lint-formats:
@@ -222,6 +238,10 @@ languages:
   python:
     - <<: *python-flake8
     - <<: *python-mypy
+    # - <<: *python-autopep8
+    # - <<: *python-yapf
+    - <<: *python-black
+    - <<: *python-isort
 
   dockerfile:
     - <<: *dockerfile-hadolint


### PR DESCRIPTION
## Tools

- **black**
    - https://github.com/psf/black
    - https://black.readthedocs.io/en/stable/ 
- **autopep8**
    - https://github.com/hhatto/autopep8
- **yapf**
    - https://github.com/google/yapf
- **isort**
    - https://github.com/PyCQA/isort
    - https://pycqa.github.io/isort/

## Capture (DEMO)

(Use `black` + `isort`)

![efmls-black-isort](https://user-images.githubusercontent.com/188642/104125656-7c935a00-539b-11eb-9197-ee519e5f7ad6.gif)
