### PR TITLE
fix whitelist to allowlist in the vim-lsp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ augroup LspEFM
   autocmd User lsp_setup call lsp#register_server({
       \ 'name': 'efm-langserver',
       \ 'cmd': {server_info->['efm-langserver', '-c=/path/to/your/config.yaml']},
-      \ 'whitelist': ['vim', 'eruby', 'markdown', 'yaml'],
+      \ 'allowlist': ['vim', 'eruby', 'markdown', 'yaml'],
       \ })
 augroup END
 ```


### PR DESCRIPTION
It's a very small fix, but I think the whitelist wasn't recommended anymore, so I fixed it.