### PR TITLE
docs(eslint): improve formatting in eslint example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,13 @@ tools:
     format-stdin: true
 
   javascript-eslint: &javascript-eslint
-    lint-command: 'eslint -f unix --stdin'
+    lint-command: 'eslint -f visualstudio --stdin --stdin-filename ${INPUT}'
     lint-ignore-exit-code: true
     lint-stdin: true
+    lint-formats:
+      - "%f(%l,%c): %tarning %m"
+      - "%f(%l,%c): %rror %m"
+
 
   php-phpstan: &php-phpstan
     lint-command: './vendor/bin/phpstan analyze --error-format raw --no-progress'


### PR DESCRIPTION
Using the unix format doesn't provide an easy way to break up the message and differentiate between errors and warnings. Changing the format to that of visualstudio gives us a message we can parse a bit better to highlight errors and warnings differently.