### PR TITLE
fix "tools" entry in schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -134,10 +134,7 @@
       "description": "definition of tools",
       "patternProperties": {
         "^([a-z0-9_-]+)+$": {
-          "items": {
-            "$ref": "#/definitions/tool-definition"
-          },
-          "type": "object"
+          "$ref": "#/definitions/tool-definition"
         }
       },
       "type": "object"


### PR DESCRIPTION
## Description

When using the current `schema.json` with `yaml-language-server`, completion and hover does not work properly in "tools" entries.

Lint is working fine.

I've adjusted the completion and hover to work as well.

## DEMO

### Before

**.vimrc(vim-lsp-settings)**

```vim
let g:lsp_settings = {
\ 'yaml-language-server': {
\   'workspace_config': {
\     'yaml': {
\       'schemas': {
\         'https://raw.githubusercontent.com/mattn/efm-langserver/master/schema.json': ['/efm-langserver/config.yaml'],
\       },
\     },
\   },
\ }
\}
```

![1-before](https://user-images.githubusercontent.com/188642/110763256-032dc000-8295-11eb-8955-d9dfb23ba1c1.gif)

### After

**.vimrc(vim-lsp-settings)**

> Set the schema.json of the branch of the pull request

```vim
let g:lsp_settings = {
\ 'yaml-language-server': {
\   'workspace_config': {
\     'yaml': {
\       'schemas': {
\         'https://raw.githubusercontent.com/yaegassy/efm-langserver/fix-schema-json/schema.json': ['/efm-langserver/config.yaml'],
\       },
\     },
\   },
\ }
\}
```

![2-after](https://user-images.githubusercontent.com/188642/110763281-0d4fbe80-8295-11eb-8398-2ac80dd30827.gif)
