### PR TITLE
Stop the lint timer only if it is set

### DIFF
--- a/langserver/handle_shutdown.go
+++ b/langserver/handle_shutdown.go
@@ -7,7 +7,10 @@ import (
 )
 
 func (h *langHandler) handleShutdown(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
-    h.lintTimer.Stop()
+	if h.lintTimer != nil {
+		h.lintTimer.Stop()
+	}
+
 	close(h.request)
 	return nil, conn.Close()
 }


### PR DESCRIPTION
Prevents a panic from happening when shutdown happens when there is no `lintTimer` defined.

Such a situation can happen if there is no lintCommand set for a given language.

Addresses the `panic` problem brought up in https://github.com/mattn/efm-langserver/issues/110#issuecomment-816541527

I've verified that the `panic` no longer happens after editing a Markdown file (for which I have only a `formatCommand` defined, without any `lintCommand`) - the process exists cleanly (verified in `~/.cache/nvim/lsp.log`)

<details>
<summary>Logs from before&after</summary>

Before:

```
[ ERROR ] 2021-04-18T12:51:37+0200 ] ...nt_nvimEd5bbH/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "2021/04/18 12:51:37 lint for LanguageID not supported: markdown\n"
[ ERROR ] 2021-04-18T12:51:38+0200 ] ...nt_nvimEd5bbH/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "2021/04/18 12:51:38 format succeeded\n"
[ ERROR ] 2021-04-18T12:51:38+0200 ] ...nt_nvimEd5bbH/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        '2021/04/18 12:51:38 jsonrpc2 handler: notification "$/cancelRequest" handling error: jsonrpc2: code -32601 message: method not supported: $/cancelRequest\n2021/04/18 12:51:38 lint for LanguageID not supported: markdown\n'
[ ERROR ] 2021-04-18T12:51:39+0200 ] ...nt_nvimEd5bbH/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "panic: runtime error: invalid memory address or nil pointer dereference\n[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x56366a]\n\ngoroutine 7 [running]:\ntime.(*Timer).Stop(...)\n\t/usr/local/go/src/time/sleep.go:76\ngithub.com/mattn/efm-langserver/langserver.(*langHandler).handleShutdown(0xc000140000, 0x5f65e0, "
[ ERROR ] 2021-04-18T12:51:39+0200 ] ...nt_nvimEd5bbH/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "0xc00001a0e0, 0xc000144000, "
[ ERROR ] 2021-04-18T12:51:39+0200 ] ...nt_nvimEd5bbH/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "0xc0001a4000, 0x595200, 0xc0004c60e0, 0xc00013c240, 0x0)\n\t/home/voreny/projects/open-source/efm-langserver/langserver/handle_shutdown.go:10 +0x2a\ngithub.com/mattn/efm-langserver/langserver.(*langHandler).handle(0xc000140000, 0x5f65e0, 0xc00001a0e0, 0xc000144000, 0xc0001a4000, 0x595200, 0xc0004c60e0"
[ ERROR ] 2021-04-18T12:51:39+0200 ] ...nt_nvimEd5bbH/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        ", 0x0, 0x0)\n\t/home/voreny/projects/open-source/efm-langserver/langserver/handler.go:559 +0x19c\ngithub.com/sourcegraph/jsonrpc2.(*HandlerWithErrorConfigurer).Handle(0xc0000104a0, 0x5f65e0, 0xc00001a0e0, 0xc000144000, 0xc0001a4000)\n\t/home/voreny/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.0.0-20191222043438-96c4efab7ee2/handler_with_error.go:21 +0x73\ngithub.com/sourcegraph/jsonrpc2.(*Conn).readMessages(0xc000144000, 0x5f65e0, 0xc00001a0e0)\n\t/home/voreny/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.0.0-20191222043438-96c4efab7ee2/jsonrpc2.go:522 +0x57e\ncreated by github.com/sourcegraph/jsonrpc2.NewConn\n\t/home/voreny/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.0.0-20191222043438-96c4efab7ee2/jsonrpc2.go:334 +0x1d5\n"
```

After:

```
[ ERROR ] 2021-04-18T12:49:00+0200 ] ...nt_nvimoNHZiP/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "2021/04/18 12:49:00 lint for LanguageID not supported: markdown\n"
[ ERROR ] 2021-04-18T12:49:00+0200 ] ...nt_nvimoNHZiP/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "2021/04/18 12:49:00 format succeeded\n"
[ ERROR ] 2021-04-18T12:49:00+0200 ] ...nt_nvimoNHZiP/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        '2021/04/18 12:49:00 jsonrpc2 handler: notification "$/cancelRequest" handling error: jsonrpc2: code -32601 message: method not supported: $/cancelRequest\n'
[ ERROR ] 2021-04-18T12:49:00+0200 ] ...nt_nvimoNHZiP/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "2021/04/18 12:49:00 lint for LanguageID not supported: markdown\n"
[ ERROR ] 2021-04-18T12:49:01+0200 ] ...nt_nvimoNHZiP/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "2021/04/18 12:49:01 jsonrpc2 handler: sending response 9: jsonrpc2: connection is closed\n"
[ ERROR ] 2021-04-18T12:49:01+0200 ] ...nt_nvimoNHZiP/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "efm-langserver"        "stderr"        "2021/04/18 12:49:01 efm-langserver: connections closed\n
```

</details>