### PR TITLE
Adding file ext var

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -589,7 +590,10 @@ func (h *langHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 }
 
 func replaceCommandInputFilename(command string, fname string) string {
+	ext := path.Ext(fname)
+	ext = strings.TrimPrefix(ext, ".")
 	command = strings.Replace(command, "${INPUT}", fname, -1)
+	command = strings.Replace(command, "${FILEEXT}", ext, -1)
 	command = strings.Replace(command, "${FILENAME}", filepath.FromSlash(fname), -1)
 	return command
 }

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -591,7 +590,7 @@ func (h *langHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 }
 
 func replaceCommandInputFilename(command string, fname string, rootPath string) string {
-	ext := path.Ext(fname)
+	ext := filepath.Ext(fname)
 	ext = strings.TrimPrefix(ext, ".")
 	command = strings.Replace(command, "${INPUT}", fname, -1)
 	command = strings.Replace(command, "${FILEEXT}", ext, -1)


### PR DESCRIPTION
Some formatters support multiple file format but requires file extension hint (eg: `deno fmt`).

Adding `FILEEXT` var might help with those kind of formatter.