### PR TITLE
Support adding LSP workspace root to command

### DIFF
--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -96,10 +96,10 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (interface{},
 	var output string
 	if !strings.HasPrefix(command.Command, ":") {
 		if runtime.GOOS == "windows" {
-			args = []string{"/c", replaceCommandInputFilename(command.Command, fname)}
+			args = []string{"/c", replaceCommandInputFilename(command.Command, fname, h.rootPath)}
 			for _, v := range command.Arguments {
 				arg := fmt.Sprint(v)
-				tmp := replaceCommandInputFilename(arg, fname)
+				tmp := replaceCommandInputFilename(arg, fname, h.rootPath)
 				if tmp != arg && fname == "" {
 					h.logger.Println("invalid uri")
 					return nil, fmt.Errorf("invalid uri: %v", uri)
@@ -109,10 +109,10 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (interface{},
 			}
 			cmd = exec.Command("cmd", args...)
 		} else {
-			args = []string{"-c", replaceCommandInputFilename(command.Command, fname)}
+			args = []string{"-c", replaceCommandInputFilename(command.Command, fname, h.rootPath)}
 			for _, v := range command.Arguments {
 				arg := fmt.Sprint(v)
-				tmp := replaceCommandInputFilename(arg, fname)
+				tmp := replaceCommandInputFilename(arg, fname, h.rootPath)
 				if tmp != arg && fname == "" {
 					h.logger.Println("invalid uri")
 					return nil, fmt.Errorf("invalid uri: %v", uri)

--- a/langserver/handle_text_document_completion.go
+++ b/langserver/handle_text_document_completion.go
@@ -78,7 +78,7 @@ func (h *langHandler) completion(uri DocumentURI, params *CompletionParams) ([]C
 		if !config.CompletionStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
-		command = replaceCommandInputFilename(command, fname)
+		command = replaceCommandInputFilename(command, fname, h.rootPath)
 
 		var cmd *exec.Cmd
 		if runtime.GOOS == "windows" {

--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -78,7 +78,7 @@ Configs:
 		if !config.FormatStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
-		command = replaceCommandInputFilename(command, fname)
+		command = replaceCommandInputFilename(command, fname, h.rootPath)
 
 		for placeholder, value := range options {
 			re, err := regexp.Compile(fmt.Sprintf(`\${([^:|^}]+):%s}`, placeholder))

--- a/langserver/handle_text_document_symbol.go
+++ b/langserver/handle_text_document_symbol.go
@@ -105,7 +105,7 @@ func (h *langHandler) symbol(uri DocumentURI) ([]SymbolInformation, error) {
 		if !config.SymbolStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
-		command = replaceCommandInputFilename(command, fname)
+		command = replaceCommandInputFilename(command, fname, h.rootPath)
 
 		formats := config.LintFormats
 		if len(formats) == 0 {

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -368,7 +368,8 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI) ([]Diagnostic, 
 		if !config.LintStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
-		command = replaceCommandInputFilename(command, fname)
+		rootPath := h.findRootPath(fname, config)
+		command = replaceCommandInputFilename(command, fname, rootPath)
 
 		formats := config.LintFormats
 		if len(formats) == 0 {
@@ -386,7 +387,7 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI) ([]Diagnostic, 
 		} else {
 			cmd = exec.CommandContext(ctx, "sh", "-c", command)
 		}
-		cmd.Dir = h.findRootPath(fname, config)
+		cmd.Dir = rootPath
 		cmd.Env = append(os.Environ(), config.Env...)
 		if config.LintStdin {
 			cmd.Stdin = strings.NewReader(f.Text)
@@ -588,8 +589,9 @@ func (h *langHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 	return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: fmt.Sprintf("method not supported: %s", req.Method)}
 }
 
-func replaceCommandInputFilename(command string, fname string) string {
+func replaceCommandInputFilename(command string, fname string, rootPath string) string {
 	command = strings.Replace(command, "${INPUT}", fname, -1)
 	command = strings.Replace(command, "${FILENAME}", filepath.FromSlash(fname), -1)
+	command = strings.Replace(command, "${ROOT}", rootPath, -1)
 	return command
 }


### PR DESCRIPTION
Some linters or formatters need the current project/workspace root to run correctly (e.g. Python isort needs it to know which modules should be considered 'local'). 

EFM already knows the calculated workspace but so far we are not exposing it. This PR adds it as a new variable `${ROOT}` to become available in the `format-command` or `lint-command`.