### PR TITLE
bugfix: index out-of-bound cases panic

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -123,7 +123,7 @@ type File struct {
 // WordAt is
 func (f *File) WordAt(pos Position) string {
 	lines := strings.Split(f.Text, "\n")
-	if pos.Line < 0 || pos.Line > len(lines) {
+	if pos.Line < 0 || pos.Line >= len(lines) {
 		return ""
 	}
 	chars := utf16.Encode([]rune(lines[pos.Line]))


### PR DESCRIPTION
The checking condition is incorrect which causes panic. The following is my stack trace.

```txt
panic: runtime error: index out of range [27] with length 27

goroutine 34 [running]:


github.com/mattn/efm-langserver/langserver.(*File).WordAt(0xc00009ba40, 0x1b, 0x11, 0x0, 0x1)
	github.com/mattn/efm-langserver/langserver/handler.go:129 +0x2f5
github.com/mattn/efm-langserver/langserver.(*langHandler).lint(0xc0000f8000, 0x11ede98, 0xc00018a000, 0xc0000d2140, 0x41, 0x0, 0x0, 0x0, 0x0, 0x105f960)
	github.com/mattn/efm-langserver/langserver/handler.go:452 +0xf39
github.com/mattn/efm-langserver/langserver.(*langHandler).linter.func1(0xc0000f8000, 0x11ede98, 0xc00018a000, 0xc0000d2140, 0x41)
	github.com/mattn/efm-langserver/langserver/handler.go:234 +0x74
created by github.com/mattn/efm-langserver/langserver.(*langHandler).linter
	github.com/mattn/efm-langserver/langserver/handler.go:233 +0xde
```