### PR TITLE
Add format debounce and improve debounce time setup

### DIFF
--- a/langserver/duration.go
+++ b/langserver/duration.go
@@ -1,0 +1,34 @@
+package langserver
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+type Duration time.Duration
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		*d = Duration(time.Duration(value))
+		return nil
+	case string:
+		tmp, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		*d = Duration(tmp)
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}

--- a/langserver/duration.go
+++ b/langserver/duration.go
@@ -6,12 +6,15 @@ import (
 	"time"
 )
 
+// Druation Wrapper for time.Duration
 type Duration time.Duration
 
+// MarshalJSON method  mash to json
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(time.Duration(d).String())
 }
 
+// UnmarshalJSON method Unmash duration from string or decimal
 func (d *Duration) UnmarshalJSON(b []byte) error {
 	var v interface{}
 	if err := json.Unmarshal(b, &v); err != nil {

--- a/langserver/duration.go
+++ b/langserver/duration.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Druation Wrapper for time.Duration
+// Duration time.Duration wrapper
 type Duration time.Duration
 
 // MarshalJSON method  mash to json

--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/sourcegraph/jsonrpc2"
 )
@@ -143,7 +144,7 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (interface{},
 			h.configs = *config.Languages
 			h.rootMarkers = *config.RootMarkers
 			h.loglevel = config.LogLevel
-			h.lintDebounce = config.LintDebounce
+			h.lintDebounce = time.Duration(config.LintDebounce)
 		}
 		h.logMessage(LogInfo, "Reloaded configuration file")
 		output = "OK"

--- a/langserver/handle_workspace_did_change_configuration.go
+++ b/langserver/handle_workspace_did_change_configuration.go
@@ -3,6 +3,7 @@ package langserver
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/sourcegraph/jsonrpc2"
 )
@@ -34,7 +35,10 @@ func (h *langHandler) didChangeConfiguration(config *Config) (interface{}, error
 		h.loglevel = config.LogLevel
 	}
 	if config.LintDebounce > 0 {
-		h.lintDebounce = config.LintDebounce
+		h.lintDebounce = time.Duration(config.LintDebounce)
+	}
+	if config.FormatDebounce > 0 {
+		h.formatDebounce = time.Duration(config.FormatDebounce)
 	}
 
 	return nil, nil

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 const name = "efm-langserver"
-const version = "0.0.30"
+const version = "0.0.31"
 
 var revision = "HEAD"
 


### PR DESCRIPTION
The PR
1) Trying to improve the lintDebounce setup.  Currently it only accepts int and it likely to mistake the time unit to ms. The golang Duration unit is ns.  That means the setup need to use 500000000 to debounce 500ms. I did a quick grep of setups (dotfiles) in github. Most people are setting this field to 500, I believe they mean to set up debounce to 500ms. The changes allow user setup the debounce to "500ms" or "0.5s".

2) Add format debounce. I saw random failures when multiple format tools were configured and will trigger lsp format multiple times. This sometime result in an incorrect result.