### PR TITLE
Update eruby config to include format-stdin=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ tools:
     lint-command: 'erb -x -T - | ruby -c'
     lint-stdin: true
     lint-offset: 1
+    format-stdin: true
     format-command: htmlbeautifier
 
   vim-vint: &vim-vint


### PR DESCRIPTION
First of all, thank you so much for building this, I am enjoying it with my neovim :)

I was having a hard time while setting up eruby linting and formatting with neovim. The linting part was fine, but the problem was with the formatting. After searching through the issues, I have found someone with a similar [issue](https://github.com/mattn/efm-langserver/issues/84).

In the end, I manage to get it to work by taking the solution from this [comment](https://github.com/mattn/efm-langserver/issues/24#issuecomment-590889562) in a closed issue.

Therefore, I am doing this PR to update the eruby config in the README.md so that it will be easier for others to setup eruby linting and formatting.