### PR TITLE
Minor cleanup, simplifications:

### DIFF
--- a/langserver/handle_text_document_completion.go
+++ b/langserver/handle_text_document_completion.go
@@ -75,7 +75,7 @@ func (h *langHandler) completion(uri DocumentURI, params *CompletionParams) ([]C
 		command := config.CompletionCommand
 
 		if strings.Contains(command, "${POSITION}") {
-			command = strings.Replace(command, "${POSITION}", fmt.Sprintf("%d:%d", params.TextDocumentPositionParams.Position.Line, params.Position.Character), -1)
+			command = strings.ReplaceAll(command, "${POSITION}", fmt.Sprintf("%d:%d", params.TextDocumentPositionParams.Position.Line, params.Position.Character))
 		}
 		if !config.CompletionStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"

--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -140,7 +140,7 @@ Configs:
 		if h.loglevel >= 1 {
 			h.logger.Println(command+":", string(b))
 		}
-		text = strings.Replace(string(b), "\r", "", -1)
+		text = strings.ReplaceAll(string(b), "\r", "")
 	}
 
 	if formated {

--- a/langserver/handle_text_document_hover.go
+++ b/langserver/handle_text_document_hover.go
@@ -107,7 +107,7 @@ func (h *langHandler) hover(uri DocumentURI, params *HoverParams) (*Hover, error
 		if !config.HoverStdin && !strings.Contains(command, "${INPUT}") {
 			command = command + " ${INPUT}"
 		}
-		command = strings.Replace(command, "${INPUT}", word, -1)
+		command = strings.ReplaceAll(command, "${INPUT}", word)
 
 		var cmd *exec.Cmd
 		if runtime.GOOS == "windows" {

--- a/langserver/handler_go112.go
+++ b/langserver/handler_go112.go
@@ -3,8 +3,5 @@
 package langserver
 
 func succeeded(err error) bool {
-	if err == nil {
-		return true
-	}
-	return false
+	return err == nil
 }

--- a/langserver/handler_go113.go
+++ b/langserver/handler_go113.go
@@ -10,8 +10,5 @@ func succeeded(err error) bool {
 	exitErr, ok := err.(*exec.ExitError)
 	// When the context is canceled, the process is killed,
 	// and the exit code is -1
-	if ok && exitErr.ExitCode() < 0 {
-		return true
-	}
-	return false
+	return ok && exitErr.ExitCode() < 0
 }

--- a/langserver/lsp.go
+++ b/langserver/lsp.go
@@ -24,8 +24,7 @@ type InitializeOptions struct {
 }
 
 // ClientCapabilities is
-type ClientCapabilities struct {
-}
+type ClientCapabilities struct{}
 
 // InitializeResult is
 type InitializeResult struct {
@@ -37,10 +36,11 @@ type MessageType int
 
 // LogError is
 const (
-	LogError   MessageType = 1
-	LogWarning             = 2
-	LogInfo                = 3
-	LogLog                 = 4
+	_ MessageType = iota
+	LogError
+	LogWarning
+	LogInfo
+	LogLog
 )
 
 // TextDocumentSyncKind is
@@ -48,9 +48,9 @@ type TextDocumentSyncKind int
 
 // TDSKNone is
 const (
-	TDSKNone        TextDocumentSyncKind = 0
-	TDSKFull                             = 1
-	TDSKIncremental                      = 2
+	TDSKNone TextDocumentSyncKind = iota
+	TDSKFull
+	TDSKIncremental
 )
 
 // CompletionProvider is
@@ -328,7 +328,7 @@ type MarkupKind string
 // PlainText is
 const (
 	PlainText MarkupKind = "plaintext"
-	Markdown             = "markdown"
+	Markdown  MarkupKind = "markdown"
 )
 
 // MarkupContent is
@@ -356,13 +356,13 @@ type CodeActionKind string
 // Empty is
 const (
 	Empty                 CodeActionKind = ""
-	QuickFix                             = "quickfix"
-	Refactor                             = "refactor"
-	RefactorExtract                      = "refactor.extract"
-	RefactorInline                       = "refactor.inline"
-	RefactorRewrite                      = "refactor.rewrite"
-	Source                               = "source"
-	SourceOrganizeImports                = "source.organizeImports"
+	QuickFix              CodeActionKind = "quickfix"
+	Refactor              CodeActionKind = "refactor"
+	RefactorExtract       CodeActionKind = "refactor.extract"
+	RefactorInline        CodeActionKind = "refactor.inline"
+	RefactorRewrite       CodeActionKind = "refactor.rewrite"
+	Source                CodeActionKind = "source"
+	SourceOrganizeImports CodeActionKind = "source.organizeImports"
 )
 
 // CodeActionContext is

--- a/main.go
+++ b/main.go
@@ -16,8 +16,10 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-const name = "efm-langserver"
-const version = "0.0.34"
+const (
+	name    = "efm-langserver"
+	version = "0.0.34"
+)
 
 var revision = "HEAD"
 


### PR DESCRIPTION
- used strings.ReplaceAll(...) instead of strings.Replace(..., -1);
- added what seems to be missing types (constants with logically related names, but different types, i.e. LogError, LogWarning);
- other, minor cleanup.