### PR TITLE
Require detect marker to run tool command

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -72,7 +72,7 @@ type Language struct {
 	HoverType          string            `yaml:"hover-type" json:"hoverType"`
 	Env                []string          `yaml:"env" json:"env"`
 	RootMarkers        []string          `yaml:"root-markers" json:"rootMarkers"`
-	RequireMarkers     bool              `yaml:"require-markers" json:"requireMarkers"`
+	RequireMarker      bool              `yaml:"require-marker" json:"requireMarker"`
 	Commands           []Command         `yaml:"commands" json:"commands"`
 }
 
@@ -120,7 +120,6 @@ type langHandler struct {
 	filename          string
 	folders           []string
 	rootMarkers       []string
-	requireMarkers    bool
 }
 
 // File is
@@ -327,7 +326,6 @@ func isFilename(s string) bool {
 }
 
 func (h *langHandler) lint(ctx context.Context, uri DocumentURI) ([]Diagnostic, error) {
-
 	f, ok := h.files[uri]
 	if !ok {
 		return nil, fmt.Errorf("document not found: %v", uri)
@@ -346,7 +344,7 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI) ([]Diagnostic, 
 	if cfgs, ok := h.configs[f.LanguageID]; ok {
 		for _, cfg := range cfgs {
 			// if we require markers and find that they dont exist we do not add the configuration
-			if dir := matchRootPath(fname, cfg.RootMarkers); dir == "" && cfg.RequireMarkers == true {
+			if dir := matchRootPath(fname, cfg.RootMarkers); dir == "" && cfg.RequireMarker == true {
 				continue
 			}
 			if cfg.LintCommand != "" {

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -296,3 +296,40 @@ func TestLintCategoryMap(t *testing.T) {
 		t.Fatalf("Severity should be %v but is: %v", 3, d[0].Severity)
 	}
 }
+
+// Test if lint is executed if required root markers for the language are missing
+func TestLintRequireRootMarker(t *testing.T) {
+	base, _ := os.Getwd()
+	file := filepath.Join(base, "foo")
+	uri := toURI(file)
+
+	h := &langHandler{
+		logger:   log.New(log.Writer(), "", log.LstdFlags),
+		rootPath: base,
+		configs: map[string][]Language{
+			"vim": {
+				{
+					LintCommand:        `echo ` + file + `:2:No it is normal!`,
+					LintIgnoreExitCode: true,
+					LintStdin:          true,
+					RequireMarkers:     true,
+					RootMarkers:        []string{".vimlintrc"},
+				},
+			},
+		},
+		files: map[DocumentURI]*File{
+			uri: &File{
+				LanguageID: "vim",
+				Text:       "scriptencoding utf-8\nabnormal!\n",
+			},
+		},
+	}
+
+	d, err := h.lint(context.Background(), uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d) != 0 {
+		t.Fatal("diagnostics should be zero as we have no root marker for the language but require one", d)
+	}
+}

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -312,7 +312,7 @@ func TestLintRequireRootMarker(t *testing.T) {
 					LintCommand:        `echo ` + file + `:2:No it is normal!`,
 					LintIgnoreExitCode: true,
 					LintStdin:          true,
-					RequireMarkers:     true,
+					RequireMarker:      true,
 					RootMarkers:        []string{".vimlintrc"},
 				},
 			},

--- a/schema.json
+++ b/schema.json
@@ -120,6 +120,10 @@
           },
           "type": "array"
         },
+        "require-markers": {
+          "description": "require markers to run linter",
+          "type": "boolean"
+        },
         "commands": {
           "$ref": "#/definitions/command-definition"
         }

--- a/schema.json
+++ b/schema.json
@@ -120,8 +120,8 @@
           },
           "type": "array"
         },
-        "require-markers": {
-          "description": "require markers to run linter",
+        "require-marker": {
+          "description": "require a marker to run linter",
           "type": "boolean"
         },
         "commands": {


### PR DESCRIPTION
This is a proposal to implement #112.
I am not 100% satisfied, maybe some people more familiar with efm-langserver can put their two cents in on how to best implement this.
At the moment we require root markers from the tool configuration, this would not work for "global" root markers. I am not sure if this is a problem or not, although if I understand correctly if no tool root markers are present the global root markers are used, this may lead to confusion.
I am also not sure if this is the right place to put this, maybe it would be better to put this "higher up" and not in the lint request execution itself.
