### PR TITLE
Fix infinite loop in matchRootPath

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -265,10 +265,7 @@ func matchRootPath(fname string, markers []string) string {
 	dir := filepath.Dir(filepath.Clean(fname))
 	var prev string
 	for dir != prev {
-		files, err := ioutil.ReadDir(dir)
-		if err != nil {
-			continue
-		}
+		files, _ := ioutil.ReadDir(dir)
 		for _, file := range files {
 			name := file.Name()
 			isDir := file.IsDir()


### PR DESCRIPTION
When file path contains non-existed folder, `ioutil.ReadDir` returns non-nil `err`, and the loop become infinite loop because `dir`, `prev` did not get updated.

When `err != nil`, `files = []` so we don't need to specially handle this error.