### PR TITLE
fixed go  install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ EOF
 ## Installation
 
 ```console
-go get github.com/mattn/efm-langserver
+go install github.com/mattn/efm-langserver@latest
 ```
 
 Homebrew


### PR DESCRIPTION
When running the old command I got this error:

```
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
After reading the [suggested docs](https://golang.org/doc/go-get-install-deprecation), I found out that the correct new command is:

```sh
go install github.com/mattn/efm-langserver@latest
 ```