### PR TITLE
Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ languages:
   elixir:
     - <<: *mix_credo
 
-  _:
+  =:
     - <<: *any-excitetranslate
 ```
 


### PR DESCRIPTION
When trying to use the `_` symbol as a wildcard for all languages it didn't work.
Looking trough the source code, it seems that `=` is the correct symbol now, which also works for me.