### PR TITLE
fix `Error: parse "": empty url` when rootUri is null

### DIFF
--- a/langserver/handle_initialize.go
+++ b/langserver/handle_initialize.go
@@ -21,12 +21,16 @@ func (h *langHandler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn,
 		return nil, err
 	}
 
-	rootPath, err := fromURI(params.RootURI)
-	if err != nil {
-		return nil, err
+	// https://microsoft.github.io/language-server-protocol/specification#initialize
+	// The rootUri of the workspace. Is null if no folder is open.
+	if params.RootURI != "" {
+		rootPath, err := fromURI(params.RootURI)
+		if err != nil {
+			return nil, err
+		}
+		h.rootPath = filepath.Clean(rootPath)
+		h.addFolder(rootPath)
 	}
-	h.rootPath = filepath.Clean(rootPath)
-	h.addFolder(rootPath)
 
 	var completion *CompletionProvider
 	var hasCompletionCommand bool = params.InitializationOptions.Completion


### PR DESCRIPTION
I was experiencing the issue reported here: https://github.com/mattn/efm-langserver/issues/157
This only seems to happen for me in the my home directory, and after investigating a bit, it seems that the root cause is that coc is sending the parameter `rootUri` as null in its first message. Here's the abbreviated message I captured:
```
  "params": {
    "processId": 356405,
    "rootPath": null,
    "rootUri": null,
    "capabilities": {
```

According to [this](https://microsoft.github.io/language-server-protocol/specification#initialize), this behavior should be supported by the LSP server, so I added a check for parsing this field.

The error happens in [this line](https://github.com/mattn/efm-langserver/blob/41a7cc3736a6208b699ef4a1371cf56acf8dac28/langserver/handler.go#L180) and the error message comes from the stdlib. Which is why it is not present in the repo source code.
The error messages reported in the issue is a combination of [this](https://github.com/golang/go/blob/315cec25bc7b5045f6081545a63cb27d44fcbde9/src/net/url/url.go#L499) error message and [this](https://github.com/golang/go/blob/315cec25bc7b5045f6081545a63cb27d44fcbde9/src/net/url/url.go#L517) one. 

This patch worked well for me, but let if you would like some changes I'll be happy to adapt it.


