### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,15 @@ require "lspconfig".efm.setup {
 }
 EOF
 ```
-
+- langague declare as a table
+```lua
+lua = {{fromatComamnd=...,formatStdin=...}} -- not lua = {fromatComamnd=...,formatStdin=...}
+-- for multi-code formatter , used for one langue:
+lua = {{fromatComamnd=...,formatStdin=...},{fromatComamnd=...,formatStdin=...}}
+```
+- install support formatter
+efm not include binary fromater for any laguages, you must install manually  
+binary formatter for lua:[LuaFormatter](https://github.com/Koihik/LuaFormatter), python:[yapf](https://github.com/google/yapf) [isort](https://github.com/PyCQA/isort)...
 ## Supported Lint tools
 
 * [vint](https://github.com/Kuniwak/vint) for Vim script


### PR DESCRIPTION
when someone config Standart `lsp` like `vimls` or `bashls`like that 
```lua
require "lspconfig".bashls.setup {}
```
it's needed one more step: it's to install `bashls` from source,  
but for `efm` lsp, it's must install binary of `efm` and multi-code formatted like `luaFormatter `or `yapf` or...