### PR TITLE
Add support for XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Example
 
 Location of config.yaml is:
 
-* UNIX: `$HOME/.config/efm-langserver/config.yaml`
+* UNIX: `$XDG_CONFIG_HOME/efm-langserver/config.yaml` or `$HOME/.config/efm-langserver/config.yaml`
 * Windows: `%APPDATA%\efm-langserver\config.yaml`
 
 Below is example for `config.yaml` for Windows.

--- a/main.go
+++ b/main.go
@@ -45,12 +45,19 @@ func main() {
 	}
 
 	if yamlfile == "" {
-		dir := os.Getenv("HOME")
-		if dir == "" && runtime.GOOS == "windows" {
-			dir = filepath.Join(os.Getenv("APPDATA"), "efm-langserver")
+		var config_home string
+
+		if runtime.GOOS == "windows" {
+			config_home = os.Getenv("APPDATA")
 		} else {
-			dir = filepath.Join(dir, ".config", "efm-langserver")
+			config_home = os.Getenv("XDG_CONFIG_HOME")
+			if config_home == "" {
+				config_home = filepath.Join(os.Getenv("HOME"), ".config")
+			}
 		}
+
+		dir := filepath.Join(config_home, "efm-langserver")
+
 		if err := os.MkdirAll(dir, 0700); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Hi, just installed this program and so far it works great, but I noticed that when launched it creates `~/.config` folder which I moved away on my system. This patch fixes this.