### PR TITLE
Support workspace level linters

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -254,25 +254,21 @@ func (h *langHandler) linter() {
 			}
 
 			for diagURI, diagnostics := range uriToDiagnostics {
-				copiedDiagnostics := diagnostics
-				copiedDiagURI := diagURI
 				if diagURI == "file:" {
-					copiedDiagURI = uri
+					diagURI = uri
 				}
-				go func() {
-					version := 0
-					if _, ok := h.files[uri]; ok {
-						version = h.files[uri].Version
-					}
-					h.conn.Notify(
-						ctx,
-						"textDocument/publishDiagnostics",
-						&PublishDiagnosticsParams{
-							URI:         copiedDiagURI,
-							Diagnostics: copiedDiagnostics,
-							Version:     version,
-						})
-				}()
+				version := 0
+				if _, ok := h.files[uri]; ok {
+					version = h.files[uri].Version
+				}
+				h.conn.Notify(
+					ctx,
+					"textDocument/publishDiagnostics",
+					&PublishDiagnosticsParams{
+						URI:         diagURI,
+						Diagnostics: diagnostics,
+						Version:     version,
+					})
 			}
 		}()
 	}


### PR DESCRIPTION
Resolves #143

Thank you for creating this great software. I would like to use `efm-langserver` with my linter to check all the files in a workspace, and need a feature described below.

- An option to support workspace wide diagnostics
  - ignore command line arguments in a cross-platform way
  - publish diagnostics for other files than a submitted document
  - appropriately erase diagnostics which no longer exist 🌟

To implement 🌟, we need to have a state for last published document URIs, because language servers should publish empty diagnostics to erase previous diagnostics as specified in LSP.
I define the state as `lastPublishedURIs`, and added `LintWorkspace` option for this feature.

I would appreciate it if you would review it.