### PR TITLE
Removed a second append of the arg

### DIFF
--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -120,7 +120,6 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (interface{},
 				}
 				arg = tmp
 				args = append(args, arg)
-				args = append(args, arg)
 			}
 			cmd = exec.Command("sh", args...)
 		}


### PR DESCRIPTION
Removed a second append of the arg when exec code action at not Windows.