### PR TITLE
langserver/handler: initialize diagnostics map with the current file

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -376,7 +376,9 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI) (map[DocumentUR
 		return map[DocumentURI][]Diagnostic{}, nil
 	}
 
-	uriToDiagnostics := map[DocumentURI][]Diagnostic{}
+	uriToDiagnostics := map[DocumentURI][]Diagnostic{
+		uri: {},
+	}
 	for i, config := range configs {
 		if config.LintWorkspace {
 			for lastPublishedURI := range h.lastPublishedURIs[f.LanguageID] {


### PR DESCRIPTION
The idea is that we still want to publish an empty list of diagnostics
if the document being processed doesn't have any errors.

Fixes #197.