### PR TITLE
feat: adjust log levels

### DIFF
--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -129,7 +129,7 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (interface{},
 		if err != nil {
 			return nil, err
 		}
-		if h.loglevel >= 1 {
+		if h.loglevel >= 3 {
 			h.logger.Print(strings.Join(cmd.Args, " ")+":", string(b))
 		}
 		output = string(b)

--- a/langserver/handle_text_document_completion.go
+++ b/langserver/handle_text_document_completion.go
@@ -98,7 +98,7 @@ func (h *langHandler) completion(uri DocumentURI, params *CompletionParams) ([]C
 			h.logger.Printf("completion command failed: %v", err)
 			return nil, fmt.Errorf("completion command failed: %v: %v", err, string(b))
 		}
-		if h.loglevel >= 1 {
+		if h.loglevel >= 3 {
 			h.logger.Println(command+":", string(b))
 		}
 

--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -83,7 +83,7 @@ func (h *langHandler) formatting(uri DocumentURI, options FormattingOptions) ([]
 
 	originalText := f.Text
 	text := originalText
-	formated := false
+	formatted := false
 
 Configs:
 	for _, config := range configs {
@@ -135,16 +135,18 @@ Configs:
 			continue
 		}
 
-		formated = true
+		formatted = true
 
-		if h.loglevel >= 1 {
+		if h.loglevel >= 3 {
 			h.logger.Println(command+":", string(b))
 		}
 		text = strings.Replace(string(b), "\r", "", -1)
 	}
 
-	if formated {
-		h.logger.Println("format succeeded")
+	if formatted {
+		if h.loglevel >= 3 {
+			h.logger.Println("format succeeded")
+		}
 		return ComputeEdits(uri, originalText, text), nil
 	}
 

--- a/langserver/handle_text_document_hover.go
+++ b/langserver/handle_text_document_hover.go
@@ -124,7 +124,7 @@ func (h *langHandler) hover(uri DocumentURI, params *HoverParams) (*Hover, error
 		if err != nil {
 			return nil, err
 		}
-		if h.loglevel >= 1 {
+		if h.loglevel >= 3 {
 			h.logger.Println(command+":", string(b))
 		}
 

--- a/langserver/handle_text_document_symbol.go
+++ b/langserver/handle_text_document_symbol.go
@@ -133,7 +133,7 @@ func (h *langHandler) symbol(uri DocumentURI) ([]SymbolInformation, error) {
 		if err != nil {
 			continue
 		}
-		if h.loglevel >= 1 {
+		if h.loglevel >= 3 {
 			h.logger.Println(command+":", string(b))
 		}
 

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -434,7 +434,7 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI) (map[DocumentUR
 			h.logMessage(LogError, "command `"+command+"` exit with zero. probably you forgot to specify `lint-ignore-exit-code: true`.")
 			continue
 		}
-		if h.loglevel >= 1 {
+		if h.loglevel >= 3 {
 			h.logger.Println(command+":", string(b))
 		}
 		var source *string


### PR DESCRIPTION
Adjusted to log at `INFO` level on format success - my neovim logs are getting a little noisy. I also went ahead and made similar changes for the other handlers.

I'm also wondering if you're interested in me writing up a change to use enums for the log levels? Something like:
```go
type LogLevel int

const (
	ERROR LogLevel = iota + 1
	WARN
	INFO
	DEBUG
	TRACE
)
```

Thanks for all your hard work!