### PR TITLE
Support setting trigger-chars and set . by default

### DIFF
--- a/langserver/handle_initialize.go
+++ b/langserver/handle_initialize.go
@@ -66,8 +66,12 @@ func (h *langHandler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn,
 	}
 
 	if hasCompletionCommand {
+		chars := []string{"."}
+		if len(h.triggerChars) > 0 {
+			chars = h.triggerChars
+		}
 		completion = &CompletionProvider{
-			TriggerCharacters: []string{"*"},
+			TriggerCharacters: chars,
 		}
 	}
 

--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -142,6 +142,7 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (interface{},
 			h.commands = *config.Commands
 			h.configs = *config.Languages
 			h.rootMarkers = *config.RootMarkers
+			h.triggerChars = config.TriggerChars
 			h.loglevel = config.LogLevel
 			h.lintDebounce = time.Duration(config.LintDebounce)
 		}

--- a/langserver/handle_workspace_did_change_configuration.go
+++ b/langserver/handle_workspace_did_change_configuration.go
@@ -28,6 +28,9 @@ func (h *langHandler) didChangeConfiguration(config *Config) (interface{}, error
 	if config.RootMarkers != nil {
 		h.rootMarkers = *config.RootMarkers
 	}
+	if config.TriggerChars != nil {
+		h.triggerChars = config.TriggerChars
+	}
 	if config.Commands != nil {
 		h.commands = *config.Commands
 	}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -30,6 +30,7 @@ type Config struct {
 	Commands       *[]Command             `yaml:"commands"        json:"commands"`
 	Languages      *map[string][]Language `yaml:"languages"       json:"languages"`
 	RootMarkers    *[]string              `yaml:"root-markers"    json:"rootMarkers"`
+	TriggerChars   []string              `yaml:"trigger-chars"   json:"triggerChars"`
 	LintDebounce   Duration               `yaml:"lint-debounce"   json:"lintDebounce"`
 	FormatDebounce Duration               `yaml:"format-debounce" json:"formatDebounce"`
 
@@ -100,6 +101,7 @@ func NewHandler(config *Config) jsonrpc2.Handler {
 		conn:           nil,
 		filename:       config.Filename,
 		rootMarkers:    *config.RootMarkers,
+		triggerChars:   config.TriggerChars,
 
 		lastPublishedURIs: make(map[string]map[DocumentURI]struct{}),
 	}
@@ -124,6 +126,7 @@ type langHandler struct {
 	filename          string
 	folders           []string
 	rootMarkers       []string
+	triggerChars      []string
 
 	// lastPublishedURIs is mapping from LanguageID string to mapping of
 	// whether diagnostics are published in a DocumentURI or not.
@@ -506,7 +509,6 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI) (map[DocumentUR
 			}
 
 			diagURI := uri
-			h.logger.Println(entry.Filename)
 			if entry.Filename != "" {
 				if filepath.IsAbs(entry.Filename) {
 					diagURI = toURI(entry.Filename)

--- a/schema.json
+++ b/schema.json
@@ -178,6 +178,13 @@
     "lint-debounce": {
       "description": "debounce for lints",
       "type": "string"
+    },
+    "trigger-chars": {
+      "description": "trigger characters for completion",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     }
   },
   "title": "efm-langserver",


### PR DESCRIPTION
- `*` is not a wildcard in `TriggerCharacters`
- Currently only literal `*` triggers completion
- Add `trigger-chars` as setting
- Set `.` by default