### PR TITLE
Fix cases without line number

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -478,6 +478,10 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI) (map[DocumentUR
 				entry.Col = entry.Col + config.LintOffsetColumns
 			}
 
+			if entry.Lnum == 0 {
+				entry.Lnum = 1 // entry.Lnum == 0 indicates the top line, set to 1 because it is subtracted later
+			}
+
 			if entry.Col == 0 {
 				entry.Col = 1 // entry.Col == 0 indicates the whole line without column, set to 1 because it is subtracted later
 			} else {

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -429,8 +429,8 @@ func TestLintMultipleFilesWithCancel(t *testing.T) {
 		configs: map[string][]Language{
 			"vim": {
 				{
-					LintCommand:        `echo ` + file + `:2:1:First file! && echo ` + file2 + `:1:2:Second file!`,
-					LintFormats:        []string{"%f:%l:%c:%m"},
+					LintCommand:        `echo ` + file + `:2:1:First file! && echo ` + file2 + `:1:2:Second file! && echo ` + file2 + `:Empty l and c!` ,
+					LintFormats:        []string{"%f:%l:%c:%m", "%f:%m"},
 					LintIgnoreExitCode: true,
 					LintWorkspace:      true,
 				},
@@ -467,6 +467,12 @@ func TestLintMultipleFilesWithCancel(t *testing.T) {
 	}
 	if d[uri2][0].Range.Start.Line != 0 {
 		t.Fatalf("second range.start.line should be %v but got: %v", 0, d[uri2][0].Range.Start.Line)
+	}
+	if d[uri2][1].Range.Start.Character != 0 {
+		t.Fatalf("second range.start.character should be %v but got: %v", 0, d[uri2][1].Range.Start.Character)
+	}
+	if d[uri2][1].Range.Start.Line != 0 {
+		t.Fatalf("second range.start.line should be %v but got: %v", 0, d[uri2][1].Range.Start.Line)
 	}
 
 	startedFlagPath := "already-started"


### PR DESCRIPTION
If `%l` is empty, the `Lnum` will be `0` and diagnostic location will be on line `-1`.
This makes diagnostics invisible in some clients such as Visual Studio Code.