### PR TITLE
Replace `golint` with `golangci-lint`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Workaround for gofmt/goimports
+*.go text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    timeout-minutes: 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.x
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1
+          args: --verbose
       - name: Test
         run: make test
-      - name: Lint
-        run: make lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,72 @@
+---
+run:
+  timeout: 5m
+output:
+  format: colored-line-number
+linters:
+  # Disable all the default linters until issues found by these are dealt with.
+  disable-all: true
+  enable:
+    - goimports
+    - govet
+    - revive
+    - typecheck
+linters-settings:
+  goimports:
+    local-prefixes: github.com/mattn/efm-langserver
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    confidence: 0.8
+    error-code: 0
+    warning-code: 0
+    rules:
+      - name: add-constant
+        arguments:
+          - maxLitCount: "3"
+            allowStrs: '""'
+            allowInts: "0,1,2,3,4,5,0700,0660"
+            allowFloats: "0.0,0.,1.0,1.,2.0,2."
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+issues:
+  exclude-rules:
+    - linters:
+        - goimports
+      path: langserver/handler_go112.go
+    - linters:
+        - goimports
+      path: langserver/handler_go113.go
+    - linters:
+        - revive
+      path: '(.+)_test\.go'
+      text: "add-constant:"
+    - linters:
+        - revive
+      path: '(.+)_test\.go'
+      text: "exported:"
+    - linters:
+        - revive
+      path: langserver/diff.go
+      text: "var-naming: don't use leading k in Go names"

--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,6 @@ $(GOBIN)/goxz:
 test: build
 	go test -v ./...
 
-.PHONY: lint
-lint: $(GOBIN)/golint
-	go vet ./...
-	golint -set_exit_status ./...
-
-$(GOBIN)/golint:
-	go install golang.org/x/lint/golint@latest
-
 .PHONY: clean
 clean:
 	rm -rf $(BIN) goxz

--- a/langserver/diff.go
+++ b/langserver/diff.go
@@ -29,7 +29,7 @@ const (
 // https://www.codeproject.com/Articles/42279/%2FArticles%2F42279%2FInvestigating-Myers-diff-algorithm-Part-1-of-2
 
 // ComputeEdits computes diff edits from 2 string inputs
-func ComputeEdits(uri DocumentURI, before, after string) []TextEdit {
+func ComputeEdits(_ DocumentURI, before, after string) []TextEdit {
 	ops := operations(splitLines(before), splitLines(after))
 	edits := make([]TextEdit, 0, len(ops))
 	for _, op := range ops {

--- a/langserver/handle_initialize.go
+++ b/langserver/handle_initialize.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleInitialize(_ context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}
@@ -33,11 +33,11 @@ func (h *langHandler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn,
 	}
 
 	var completion *CompletionProvider
-	var hasCompletionCommand bool = params.InitializationOptions.Completion
-	var hasHoverCommand bool = params.InitializationOptions.Hover
-	var hasCodeActionCommand bool = params.InitializationOptions.CodeAction
-	var hasSymbolCommand bool = params.InitializationOptions.DocumentSymbol
-	var hasFormatCommand bool = params.InitializationOptions.DocumentFormatting
+	hasCompletionCommand := params.InitializationOptions.Completion
+	hasHoverCommand := params.InitializationOptions.Hover
+	hasCodeActionCommand := params.InitializationOptions.CodeAction
+	hasSymbolCommand := params.InitializationOptions.DocumentSymbol
+	hasFormatCommand := params.InitializationOptions.DocumentFormatting
 	var hasDefinitionCommand bool
 
 	if len(h.commands) > 0 {

--- a/langserver/handle_shutdown.go
+++ b/langserver/handle_shutdown.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleShutdown(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleShutdown(_ context.Context, conn *jsonrpc2.Conn, _ *jsonrpc2.Request) (result interface{}, err error) {
 	if h.lintTimer != nil {
 		h.lintTimer.Stop()
 	}

--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentCodeAction(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentCodeAction(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}
@@ -176,7 +176,7 @@ func filterCommands(uri DocumentURI, commands []Command) []Command {
 	return results
 }
 
-func (h *langHandler) codeAction(uri DocumentURI, params *CodeActionParams) ([]Command, error) {
+func (h *langHandler) codeAction(uri DocumentURI, _ *CodeActionParams) ([]Command, error) {
 	f, ok := h.files[uri]
 	if !ok {
 		return nil, fmt.Errorf("document not found: %v", uri)

--- a/langserver/handle_text_document_completion.go
+++ b/langserver/handle_text_document_completion.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentCompletion(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentCompletion(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_text_document_definition.go
+++ b/langserver/handle_text_document_definition.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentDefinition(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentDefinition(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_text_document_did_change.go
+++ b/langserver/handle_text_document_did_change.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentDidChange(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentDidChange(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_text_document_did_close.go
+++ b/langserver/handle_text_document_did_close.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentDidClose(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentDidClose(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_text_document_did_open.go
+++ b/langserver/handle_text_document_did_open.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentDidOpen(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentDidOpen(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_text_document_did_save.go
+++ b/langserver/handle_text_document_did_save.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentDidSave(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentDidSave(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentFormatting(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentFormatting(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_text_document_hover.go
+++ b/langserver/handle_text_document_hover.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentHover(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentHover(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_text_document_symbol.go
+++ b/langserver/handle_text_document_symbol.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleTextDocumentSymbol(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleTextDocumentSymbol(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_workspace_did_change_configuration.go
+++ b/langserver/handle_workspace_did_change_configuration.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleWorkspaceDidChangeConfiguration(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleWorkspaceDidChangeConfiguration(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_workspace_did_change_workspace_folders.go
+++ b/langserver/handle_workspace_did_change_workspace_folders.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleDidChangeWorkspaceWorkspaceFolders(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleDidChangeWorkspaceWorkspaceFolders(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_workspace_execute_command.go
+++ b/langserver/handle_workspace_execute_command.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleWorkspaceExecuteCommand(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleWorkspaceExecuteCommand(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handle_workspace_workspace_folders.go
+++ b/langserver/handle_workspace_workspace_folders.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *langHandler) handleWorkspaceWorkspaceFolders(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handleWorkspaceWorkspaceFolders(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 	}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -17,9 +17,10 @@ import (
 	"unicode"
 	"unicode/utf16"
 
-	"github.com/mattn/go-unicodeclass"
 	"github.com/reviewdog/errorformat"
 	"github.com/sourcegraph/jsonrpc2"
+
+	"github.com/mattn/go-unicodeclass"
 )
 
 // Config is
@@ -30,7 +31,7 @@ type Config struct {
 	Commands       *[]Command             `yaml:"commands"        json:"commands"`
 	Languages      *map[string][]Language `yaml:"languages"       json:"languages"`
 	RootMarkers    *[]string              `yaml:"root-markers"    json:"rootMarkers"`
-	TriggerChars   []string              `yaml:"trigger-chars"   json:"triggerChars"`
+	TriggerChars   []string               `yaml:"trigger-chars"   json:"triggerChars"`
 	LintDebounce   Duration               `yaml:"lint-debounce"   json:"lintDebounce"`
 	FormatDebounce Duration               `yaml:"format-debounce" json:"formatDebounce"`
 

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -106,7 +106,7 @@ func TestLintFileMatchedForce(t *testing.T) {
 			},
 		},
 		files: map[DocumentURI]*File{
-			uri: &File{
+			uri: {
 				LanguageID: "vim",
 				Text:       "scriptencoding utf-8\nabnormal!\n",
 			},
@@ -157,7 +157,7 @@ func TestLintOffsetColumnsZero(t *testing.T) {
 			},
 		},
 		files: map[DocumentURI]*File{
-			uri: &File{
+			uri: {
 				LanguageID: "vim",
 				Text:       "scriptencoding utf-8\nabnormal!\n",
 			},
@@ -198,7 +198,7 @@ func TestLintOffsetColumnsNoOffset(t *testing.T) {
 			},
 		},
 		files: map[DocumentURI]*File{
-			uri: &File{
+			uri: {
 				LanguageID: "vim",
 				Text:       "scriptencoding utf-8\nabnormal!\n",
 			},
@@ -240,7 +240,7 @@ func TestLintOffsetColumnsNonZero(t *testing.T) {
 			},
 		},
 		files: map[DocumentURI]*File{
-			uri: &File{
+			uri: {
 				LanguageID: "vim",
 				Text:       "scriptencoding utf-8\nabnormal!\n",
 			},
@@ -285,7 +285,7 @@ func TestLintCategoryMap(t *testing.T) {
 			},
 		},
 		files: map[DocumentURI]*File{
-			uri: &File{
+			uri: {
 				LanguageID: "vim",
 				Text:       "scriptencoding utf-8\nabnormal!\n",
 			},
@@ -326,7 +326,7 @@ func TestLintRequireRootMarker(t *testing.T) {
 			},
 		},
 		files: map[DocumentURI]*File{
-			uri: &File{
+			uri: {
 				LanguageID: "vim",
 				Text:       "scriptencoding utf-8\nabnormal!\n",
 			},
@@ -429,7 +429,7 @@ func TestLintMultipleFilesWithCancel(t *testing.T) {
 		configs: map[string][]Language{
 			"vim": {
 				{
-					LintCommand:        `echo ` + file + `:2:1:First file! && echo ` + file2 + `:1:2:Second file! && echo ` + file2 + `:Empty l and c!` ,
+					LintCommand:        `echo ` + file + `:2:1:First file! && echo ` + file2 + `:1:2:Second file! && echo ` + file2 + `:Empty l and c!`,
 					LintFormats:        []string{"%f:%l:%c:%m", "%f:%m"},
 					LintIgnoreExitCode: true,
 					LintWorkspace:      true,

--- a/main.go
+++ b/main.go
@@ -10,10 +10,10 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/sourcegraph/jsonrpc2"
 	"gopkg.in/yaml.v3"
 
 	"github.com/mattn/efm-langserver/langserver"
-	"github.com/sourcegraph/jsonrpc2"
 )
 
 const (


### PR DESCRIPTION
`golangci-lint` is a Go linters aggregator: https://golangci-lint.run/

`golint` is currently unmantained, `revive` attempts to be a replacement
for it.

For now we only enable very basic linters + `revive`, more linters will be
added in the future.