### PR TITLE
Update to Go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,15 @@
 module github.com/mattn/efm-langserver
 
-go 1.13
+go 1.19
 
 require (
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-unicodeclass v0.0.1
 	github.com/reviewdog/errorformat v0.0.0-20220309155058-b075c45b6d9a
 	github.com/sourcegraph/jsonrpc2 v0.1.0
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/kr/pretty v0.1.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/langserver/duration.go
+++ b/langserver/duration.go
@@ -16,7 +16,7 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON method Unmash duration from string or decimal
 func (d *Duration) UnmarshalJSON(b []byte) error {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalYAML method Unmash duration from string or decimal
-func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err

--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -27,7 +27,7 @@ func (h *langHandler) handleTextDocumentCodeAction(_ context.Context, _ *jsonrpc
 	return h.codeAction(params.TextDocument.URI, &params)
 }
 
-func (h *langHandler) executeCommand(params *ExecuteCommandParams) (interface{}, error) {
+func (h *langHandler) executeCommand(params *ExecuteCommandParams) (any, error) {
 	if len(params.Arguments) != 1 {
 		return nil, fmt.Errorf("invalid command")
 	}
@@ -170,7 +170,7 @@ func filterCommands(uri DocumentURI, commands []Command) []Command {
 		results = append(results, Command{
 			Title:     v.Title,
 			Command:   fmt.Sprintf("efm-langserver\t%s\t%s", v.Command, string(uri)),
-			Arguments: []interface{}{string(uri)},
+			Arguments: []any{string(uri)},
 		})
 	}
 	return results

--- a/langserver/handle_workspace_did_change_configuration.go
+++ b/langserver/handle_workspace_did_change_configuration.go
@@ -21,7 +21,7 @@ func (h *langHandler) handleWorkspaceDidChangeConfiguration(_ context.Context, _
 	return h.didChangeConfiguration(&params.Settings)
 }
 
-func (h *langHandler) didChangeConfiguration(config *Config) (interface{}, error) {
+func (h *langHandler) didChangeConfiguration(config *Config) (any, error) {
 	if config.Languages != nil {
 		h.configs = *config.Languages
 	}

--- a/langserver/handle_workspace_did_change_workspace_folders.go
+++ b/langserver/handle_workspace_did_change_workspace_folders.go
@@ -20,7 +20,7 @@ func (h *langHandler) handleDidChangeWorkspaceWorkspaceFolders(_ context.Context
 	return h.didChangeWorkspaceFolders(&params)
 }
 
-func (h *langHandler) didChangeWorkspaceFolders(params *DidChangeWorkspaceFoldersParams) (result interface{}, err error) {
+func (h *langHandler) didChangeWorkspaceFolders(params *DidChangeWorkspaceFoldersParams) (result any, err error) {
 	var folders []string
 	for _, removed := range params.Event.Removed {
 		for _, folder := range h.folders {

--- a/langserver/handle_workspace_workspace_folders.go
+++ b/langserver/handle_workspace_workspace_folders.go
@@ -15,7 +15,7 @@ func (h *langHandler) handleWorkspaceWorkspaceFolders(_ context.Context, _ *json
 	return h.workspaceFolders()
 }
 
-func (h *langHandler) workspaceFolders() (result interface{}, err error) {
+func (h *langHandler) workspaceFolders() (result any, err error) {
 	workspaces := []WorkspaceFolder{}
 	for _, workspace := range h.folders {
 		workspaces = append(workspaces, WorkspaceFolder{

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -625,7 +625,7 @@ func (h *langHandler) addFolder(folder string) {
 	}
 }
 
-func (h *langHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *langHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	switch req.Method {
 	case "initialize":
 		return h.handleInitialize(ctx, conn, req)

--- a/langserver/lsp.go
+++ b/langserver/lsp.go
@@ -195,7 +195,7 @@ type PublishDiagnosticsParams struct {
 }
 
 // FormattingOptions is
-type FormattingOptions map[string]interface{}
+type FormattingOptions map[string]any
 
 // DocumentFormattingParams is
 type DocumentFormattingParams struct {
@@ -269,16 +269,16 @@ const (
 
 // Command is
 type Command struct {
-	Title     string        `json:"title" yaml:"title"`
-	Command   string        `json:"command" yaml:"command"`
-	Arguments []interface{} `json:"arguments,omitempty" yaml:"arguments,omitempty"`
-	OS        string        `json:"-" yaml:"os,omitempty"`
+	Title     string `json:"title" yaml:"title"`
+	Command   string `json:"command" yaml:"command"`
+	Arguments []any  `json:"arguments,omitempty" yaml:"arguments,omitempty"`
+	OS        string `json:"-" yaml:"os,omitempty"`
 }
 
 // WorkspaceEdit is
 type WorkspaceEdit struct {
-	Changes         interface{} `json:"changes"`         // { [uri: DocumentUri]: TextEdit[]; };
-	DocumentChanges interface{} `json:"documentChanges"` // (TextDocumentEdit[] | (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]);
+	Changes         any `json:"changes"`         // { [uri: DocumentUri]: TextEdit[]; };
+	DocumentChanges any `json:"documentChanges"` // (TextDocumentEdit[] | (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]);
 }
 
 // CodeAction is
@@ -307,13 +307,13 @@ type CompletionItem struct {
 	AdditionalTextEdits []TextEdit          `json:"additionalTextEdits,omitempty"`
 	CommitCharacters    []string            `json:"commitCharacters,omitempty"`
 	Command             *Command            `json:"command,omitempty"`
-	Data                interface{}         `json:"data,omitempty"`
+	Data                any                 `json:"data,omitempty"`
 }
 
 // Hover is
 type Hover struct {
-	Contents interface{} `json:"contents"`
-	Range    *Range      `json:"range"`
+	Contents any    `json:"contents"`
+	Range    *Range `json:"range"`
 }
 
 // MarkedString is
@@ -339,15 +339,15 @@ type MarkupContent struct {
 
 // WorkDoneProgressParams is
 type WorkDoneProgressParams struct {
-	WorkDoneToken interface{} `json:"workDoneToken"`
+	WorkDoneToken any `json:"workDoneToken"`
 }
 
 // ExecuteCommandParams is
 type ExecuteCommandParams struct {
 	WorkDoneProgressParams
 
-	Command   string        `json:"command"`
-	Arguments []interface{} `json:"arguments,omitempty"`
+	Command   string `json:"command"`
+	Arguments []any  `json:"arguments,omitempty"`
 }
 
 // CodeActionKind is
@@ -373,7 +373,7 @@ type CodeActionContext struct {
 
 // PartialResultParams is
 type PartialResultParams struct {
-	PartialResultToken interface{} `json:"partialResultToken"`
+	PartialResultToken any `json:"partialResultToken"`
 }
 
 // CodeActionParams is
@@ -393,8 +393,8 @@ type DidChangeConfigurationParams struct {
 
 // NotificationMessage is
 type NotificationMessage struct {
-	Method string      `json:"message"`
-	Params interface{} `json:"params"`
+	Method string `json:"message"`
+	Params any    `json:"params"`
 }
 
 // DocumentDefinitionParams is


### PR DESCRIPTION
Also, `interface{}` was replaced by `any` by running:
`gofmt -w -r 'interface{} -> any'`