### PR TITLE
Override capability when initialization options are set.

### DIFF
--- a/langserver/handle_initialize.go
+++ b/langserver/handle_initialize.go
@@ -33,11 +33,11 @@ func (h *langHandler) handleInitialize(_ context.Context, conn *jsonrpc2.Conn, r
 	}
 
 	var completion *CompletionProvider
-	hasCompletionCommand := params.InitializationOptions.Completion
-	hasHoverCommand := params.InitializationOptions.Hover
-	hasCodeActionCommand := params.InitializationOptions.CodeAction
-	hasSymbolCommand := params.InitializationOptions.DocumentSymbol
-	hasFormatCommand := params.InitializationOptions.DocumentFormatting
+	var hasCompletionCommand bool
+	var hasHoverCommand bool
+	var hasCodeActionCommand bool
+	var hasSymbolCommand bool
+	var hasFormatCommand bool
 	var hasDefinitionCommand bool
 
 	if len(h.commands) > 0 {
@@ -63,6 +63,14 @@ func (h *langHandler) handleInitialize(_ context.Context, conn *jsonrpc2.Conn, r
 				hasFormatCommand = true
 			}
 		}
+	}
+
+	if params.InitializationOptions != nil {
+		hasCompletionCommand = params.InitializationOptions.Completion
+		hasHoverCommand = params.InitializationOptions.Hover
+		hasCodeActionCommand = params.InitializationOptions.CodeAction
+		hasSymbolCommand = params.InitializationOptions.DocumentSymbol
+		hasFormatCommand = params.InitializationOptions.DocumentFormatting
 	}
 
 	if hasCompletionCommand {

--- a/langserver/lsp.go
+++ b/langserver/lsp.go
@@ -9,7 +9,7 @@ type DocumentURI string
 type InitializeParams struct {
 	ProcessID             int                `json:"processId,omitempty"`
 	RootURI               DocumentURI        `json:"rootUri,omitempty"`
-	InitializationOptions InitializeOptions  `json:"initializationOptions,omitempty"`
+	InitializationOptions *InitializeOptions `json:"initializationOptions,omitempty"`
 	Capabilities          ClientCapabilities `json:"capabilities,omitempty"`
 	Trace                 string             `json:"trace,omitempty"`
 }


### PR DESCRIPTION
When https://github.com/tsuyoshicho/vim-efm-langserver-settings is used, `config.yaml` is provided.
However, if you want to disable some features, it is useful to be able to override the capability with `initializationOptions`.