### PR TITLE
Fix data race in text document formatting

### DIFF
--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -37,9 +37,13 @@ func (h *langHandler) formatRequest(uri DocumentURI, opt FormattingOptions) ([]T
 		return []TextEdit{}, nil
 	}
 
+	h.mu.Lock()
 	h.formatTimer = time.AfterFunc(h.formatDebounce, func() {
+		h.mu.Lock()
 		h.formatTimer = nil
+		h.mu.Unlock()
 	})
+	h.mu.Unlock()
 	return h.formatting(uri, opt)
 }
 

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 	"unicode/utf16"
@@ -111,6 +112,7 @@ func NewHandler(config *Config) jsonrpc2.Handler {
 }
 
 type langHandler struct {
+	mu                sync.Mutex
 	loglevel          int
 	logger            *log.Logger
 	commands          []Command


### PR DESCRIPTION
This pull request fixes a data race in text document formatting from the master 34b8f5bf9c80a361c56245131fa23b197f94b293


```
$ go test  ./... -race


?   	github.com/mattn/efm-langserver	[no test files]
[]
==================
WARNING: DATA RACE
Write at 0x00c0001823e0 by goroutine 10:
  github.com/mattn/efm-langserver/langserver.(*langHandler).formatRequest.func1()
      /Users/khant/temp/efm-langserver/langserver/handle_text_document_formatting.go:41 +0x3e

Previous write at 0x00c0001823e0 by goroutine 8:
  github.com/mattn/efm-langserver/langserver.(*langHandler).formatRequest()
      /Users/khant/temp/efm-langserver/langserver/handle_text_document_formatting.go:40 +0x1cd
  github.com/mattn/efm-langserver/langserver.TestFormattingRequireRootMatcher()
      /Users/khant/temp/efm-langserver/langserver/handle_text_document_formatting_test.go:37 +0x6ad
  testing.tRunner()
      /Users/khant/local/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /Users/khant/local/go/src/testing/testing.go:1629 +0x47

Goroutine 10 (running) created at:
  time.goFunc()
      /Users/khant/local/go/src/time/sleep.go:176 +0x47

Goroutine 8 (finished) created at:
  testing.(*T).Run()
      /Users/khant/local/go/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /Users/khant/local/go/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /Users/khant/local/go/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /Users/khant/local/go/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /Users/khant/local/go/src/testing/testing.go:1906 +0xb44
  main.main()
      _testmain.go:77 +0x2e9
==================
FAIL
FAIL	github.com/mattn/efm-langserver/langserver	0.784s
FAIL
```