### PR TITLE
Fix typo (Eglot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ coc-settings.json
   },
 ```
 
-### Configuration for [elgot](https://github.com/joaotavora/eglot)
+### Configuration for [Eglot](https://github.com/joaotavora/eglot)
 
 Add to eglot-server-programs with major mode you want.
 


### PR DESCRIPTION
[Eglot](https://github.com/joaotavora/eglot) is stands for Emacs Polyglot, not Elgot.