### PR TITLE
fix: avoid fake formatter err

### DIFF
--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -210,7 +210,10 @@ Configs:
 		text = strings.Replace(string(b), "\r", "", -1)
 	}
 
-	if formatted {
+	if text == originalText || text == "" {
+		// probably it was formatted in place
+		return nil, nil
+	} else if formatted {
 		if h.loglevel >= 3 {
 			h.logger.Println("format succeeded")
 		}


### PR DESCRIPTION
seems it is difficult to know it was really formatter not supported or it was done in place,
perhaps just better to leave it (code fs content) as it was if failed, and not giving maybe incorrect err msg.