### PR TITLE
fix: compare URI case insensitive

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -556,7 +556,8 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 					continue
 				}
 			} else {
-				if diagURI != uri && !config.LintWorkspace {
+				diagFname, _ := fromURI(diagURI)
+				if diagFname != fname && !config.LintWorkspace {
 					continue
 				}
 			}


### PR DESCRIPTION
Neovim sends filenames to LSP as URI using lower case %-encoding.
For some tools (when `entry.Filename` is not empty) current implementation converts filename to URI (using upper case %-encoding) and then compare two URI in case-sensitive way.
This result in hard to notice issue: if filename contains non-ASCII symbols then some linters work (e.g. `djlint`) while others (e.g. `markdownlint`) doesn't work. And "doesn't work" here means Neovim gets no diagnostics even if there are some errors.