### PR TITLE
Update README.md for newer neovim configuration methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Neovim's built-in LSP client sends `DidChangeConfiguration`, so `config.yaml` is
 `init.lua` example (`settings` follows [`schema.md`](schema.md)):
 
 ```lua
-require "lspconfig".efm.setup {
+vim.lsp.config("efm", {
     init_options = {documentFormatting = true},
     settings = {
         rootMarkers = {".git/"},
@@ -467,7 +467,8 @@ require "lspconfig".efm.setup {
             }
         }
     }
-}
+})
+vim.lsp.enable("efm")
 ```
 
 You can get premade tool definitions from [`creativenull/efmls-configs-nvim`](https://github.com/creativenull/efmls-configs-nvim):


### PR DESCRIPTION
nvim-lspconfig suggests switching off of the old setup{} methodology and to vim.lsp.config and vim.lsp.enable

Please see the README.md of [nvim-lspconfig](github.com/neovim/nvim-lspconfig) and you'll see the important indicator at the time