### PR TITLE
Fix panic when linter reports a type not in lint-category-map

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -525,7 +525,9 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 
 			// we allow the config to provide a mapping between LSP types E,W,I,N and whatever categories the linter has
 			if len(config.LintCategoryMap) > 0 {
-				entry.Type = []rune(config.LintCategoryMap[string(entry.Type)])[0]
+				if mapped, ok := config.LintCategoryMap[string(entry.Type)]; ok && mapped != "" {
+					entry.Type = []rune(mapped)[0]
+				}
 			}
 
 			severity := 1

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -305,6 +305,51 @@ func TestLintCategoryMap(t *testing.T) {
 	}
 }
 
+func TestLintCategoryMapUnmappedType(t *testing.T) {
+	base, _ := os.Getwd()
+	file := filepath.Join(base, "foo")
+	uri := toURI(file)
+
+	mapping := make(map[string]string)
+	mapping["R"] = "I" // pylint refactoring to info
+
+	formats := []string{"%f:%l:%c:%t:%m"}
+
+	h := &langHandler{
+		logger:   log.New(log.Writer(), "", log.LstdFlags),
+		rootPath: base,
+		configs: map[string][]Language{
+			wildcard: {
+				{
+					LintCommand:        `echo ` + file + `:2:1:W:type not in the map`,
+					LintIgnoreExitCode: true,
+					LintStdin:          true,
+					LintFormats:        formats,
+					LintCategoryMap:    mapping,
+				},
+			},
+		},
+		files: map[DocumentURI]*File{
+			uri: {
+				LanguageID: "vim",
+				Text:       "scriptencoding utf-8\nabnormal!\n",
+			},
+		},
+	}
+
+	uriToDiag, err := h.lint(context.Background(), uri, eventTypeChange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := uriToDiag[uri]
+	if len(d) != 1 {
+		t.Fatal("diagnostics should be only one")
+	}
+	if d[0].Severity != 2 {
+		t.Fatalf("Severity should be %v but is: %v", 2, d[0].Severity)
+	}
+}
+
 // Test if lint is executed if required root markers for the language are missing
 func TestLintRequireRootMarker(t *testing.T) {
 	base, _ := os.Getwd()


### PR DESCRIPTION
When lint-category-map is set and the linter emits an error type that is not present in the map, indexing `[]rune("")[0]` panics and crashes the server. Keep the original type when the lookup misses. Adds a regression test.