### PR TITLE
Fix hover-chars default not applied in LoadConfig

### DIFF
--- a/langserver/config.go
+++ b/langserver/config.go
@@ -48,9 +48,9 @@ func LoadConfig(yamlfile string) (*Config, error) {
 	}
 	config.Filename = yamlfile
 	for _, v := range *config.Languages {
-		for _, l := range v {
-			if l.HoverChars == "" {
-				l.HoverChars = "_"
+		for i := range v {
+			if v[i].HoverChars == "" {
+				v[i].HoverChars = "_"
 			}
 		}
 	}

--- a/langserver/config_test.go
+++ b/langserver/config_test.go
@@ -1,0 +1,44 @@
+package langserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigHoverCharsDefault(t *testing.T) {
+	dir := t.TempDir()
+	yamlfile := filepath.Join(dir, "config.yaml")
+	content := `version: 2
+languages:
+  vim:
+    - hover-command: 'echo hover'
+  lua:
+    - hover-command: 'echo hover'
+      hover-chars: '.'
+`
+	if err := os.WriteFile(yamlfile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := LoadConfig(yamlfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vim := (*config.Languages)["vim"]
+	if len(vim) != 1 {
+		t.Fatalf("vim should have one language config but got: %v", vim)
+	}
+	if vim[0].HoverChars != "_" {
+		t.Fatalf("hover-chars should default to %q but got: %q", "_", vim[0].HoverChars)
+	}
+
+	lua := (*config.Languages)["lua"]
+	if len(lua) != 1 {
+		t.Fatalf("lua should have one language config but got: %v", lua)
+	}
+	if lua[0].HoverChars != "." {
+		t.Fatalf("hover-chars should be %q but got: %q", ".", lua[0].HoverChars)
+	}
+}


### PR DESCRIPTION
LoadConfig assigned the `hover-chars` default to a range-loop copy of the Language struct, so the `_` default never took effect. Assign through the slice index instead. Adds a test.