### PR TITLE
Fix debounced lint dropping requests for other files

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -113,6 +113,7 @@ func NewHandler(config *Config) jsonrpc2.Handler {
 		request:           make(chan lintRequest),
 		lintDebounce:      time.Duration(config.LintDebounce),
 		lintTimer:         nil,
+		pendingLints:      make(map[DocumentURI]eventType),
 
 		formatDebounce: time.Duration(config.FormatDebounce),
 		formatTimer:    nil,
@@ -138,6 +139,7 @@ type langHandler struct {
 	request           chan lintRequest
 	lintDebounce      time.Duration
 	lintTimer         *time.Timer
+	pendingLints      map[DocumentURI]eventType
 	formatDebounce    time.Duration
 	formatTimer       *time.Timer
 	conn              *jsonrpc2.Conn
@@ -231,14 +233,23 @@ func toURI(path string) DocumentURI {
 	}).String())
 }
 
-func (h *langHandler) lintRequest(uri DocumentURI, eventType eventType) {
+func (h *langHandler) lintRequest(uri DocumentURI, event eventType) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.pendingLints[uri] = event
 	if h.lintTimer != nil {
 		h.lintTimer.Reset(h.lintDebounce)
 		return
 	}
 	h.lintTimer = time.AfterFunc(h.lintDebounce, func() {
+		h.mu.Lock()
 		h.lintTimer = nil
-		h.request <- lintRequest{URI: uri, EventType: eventType}
+		pending := h.pendingLints
+		h.pendingLints = make(map[DocumentURI]eventType)
+		h.mu.Unlock()
+		for pendingURI, pendingEventType := range pending {
+			h.request <- lintRequest{URI: pendingURI, EventType: pendingEventType}
+		}
 	})
 }
 

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -11,6 +11,28 @@ import (
 	"time"
 )
 
+func TestLintRequestDebounceKeepsAllURIs(t *testing.T) {
+	h := &langHandler{
+		lintDebounce: 10 * time.Millisecond,
+		request:      make(chan lintRequest),
+		pendingLints: make(map[DocumentURI]eventType),
+	}
+
+	h.lintRequest("file:///a", eventTypeChange)
+	h.lintRequest("file:///b", eventTypeChange)
+
+	got := map[DocumentURI]bool{}
+	timeout := time.After(3 * time.Second)
+	for len(got) < 2 {
+		select {
+		case req := <-h.request:
+			got[req.URI] = true
+		case <-timeout:
+			t.Fatalf("timed out waiting for lint requests, got: %v", got)
+		}
+	}
+}
+
 func TestLintNoLinter(t *testing.T) {
 	h := &langHandler{
 		logger:  log.New(log.Writer(), "", log.LstdFlags),


### PR DESCRIPTION
When a lint request arrived while the debounce timer was pending, the timer was reset but the new URI was discarded, so editing a second file within the debounce window never linted it. Track pending URIs and flush them all when the timer fires. Also guards the timer with the mutex to fix a data race between the handler goroutine and the timer callback. Adds a test.