### PR TITLE
Fix duplicate symbols when a line matches multiple symbol formats

### DIFF
--- a/langserver/handle_text_document_symbol.go
+++ b/langserver/handle_text_document_symbol.go
@@ -139,53 +139,57 @@ func (h *langHandler) symbol(uri DocumentURI) ([]SymbolInformation, error) {
 
 		scanner := bufio.NewScanner(bytes.NewReader(b))
 		for scanner.Scan() {
+			var m *errorformat.Match
 			for _, ef := range efms.Efms {
-				m := ef.Match(string(scanner.Text()))
-				if m == nil {
-					continue
+				m = ef.Match(string(scanner.Text()))
+				if m != nil {
+					break
 				}
-				if config.SymbolStdin && (m.F == "stdin" || m.F == "-" || m.F == "<text>") {
-					m.F = fname
-				} else {
-					m.F = filepath.ToSlash(m.F)
-				}
-				if m.C == 0 {
-					m.C = 1
-				}
-				path, err := filepath.Abs(m.F)
-				if err != nil {
-					h.logger.Println(err)
-					continue
-				}
-				path = filepath.ToSlash(path)
-				if runtime.GOOS == "windows" {
-					path = strings.ToLower(path)
-				}
-				if path != fname {
-					h.logger.Println(path, fname)
-					continue
-				}
-				token := strings.SplitN(m.M, "!", 2)
-				kind := symbolKindMap["key"]
-				if len(token) == 2 {
-					if tmp, ok := symbolKindMap[strings.ToLower(token[0])]; ok {
-						kind = tmp
-					}
-				} else {
-					token = []string{"", m.M}
-				}
-				symbols = append(symbols, SymbolInformation{
-					Location: Location{
-						URI: uri,
-						Range: Range{
-							Start: Position{Line: m.L - 1 - config.LintOffset, Character: m.C - 1},
-							End:   Position{Line: m.L - 1 - config.LintOffset, Character: m.C - 1},
-						},
-					},
-					Kind: int64(kind),
-					Name: token[1],
-				})
 			}
+			if m == nil {
+				continue
+			}
+			if config.SymbolStdin && (m.F == "stdin" || m.F == "-" || m.F == "<text>") {
+				m.F = fname
+			} else {
+				m.F = filepath.ToSlash(m.F)
+			}
+			if m.C == 0 {
+				m.C = 1
+			}
+			path, err := filepath.Abs(m.F)
+			if err != nil {
+				h.logger.Println(err)
+				continue
+			}
+			path = filepath.ToSlash(path)
+			if runtime.GOOS == "windows" {
+				path = strings.ToLower(path)
+			}
+			if path != fname {
+				h.logger.Println(path, fname)
+				continue
+			}
+			token := strings.SplitN(m.M, "!", 2)
+			kind := symbolKindMap["key"]
+			if len(token) == 2 {
+				if tmp, ok := symbolKindMap[strings.ToLower(token[0])]; ok {
+					kind = tmp
+				}
+			} else {
+				token = []string{"", m.M}
+			}
+			symbols = append(symbols, SymbolInformation{
+				Location: Location{
+					URI: uri,
+					Range: Range{
+						Start: Position{Line: m.L - 1 - config.LintOffset, Character: m.C - 1},
+						End:   Position{Line: m.L - 1 - config.LintOffset, Character: m.C - 1},
+					},
+				},
+				Kind: int64(kind),
+				Name: token[1],
+			})
 		}
 	}
 

--- a/langserver/handle_text_document_symbol_test.go
+++ b/langserver/handle_text_document_symbol_test.go
@@ -49,3 +49,43 @@ func TestSymbolFormats(t *testing.T) {
 		t.Fatalf("range.start.line should be %v but got: %v", 1, symbols[0].Location.Range.Start.Line)
 	}
 }
+
+func TestSymbolNoDuplicateWhenMultipleFormatsMatch(t *testing.T) {
+	base, _ := os.Getwd()
+	file := filepath.Join(base, "foo")
+	uri := toURI(file)
+
+	h := &langHandler{
+		logger:   log.New(log.Writer(), "", log.LstdFlags),
+		rootPath: base,
+		configs: map[string][]Language{
+			"vim": {
+				{
+					SymbolCommand: `echo ` + file + `:2:1:function!MyFunc`,
+					SymbolStdin:   true,
+					SymbolFormats: []string{"%f:%l:%c:%m", "%f:%l:%m"},
+				},
+			},
+		},
+		files: map[DocumentURI]*File{
+			uri: {
+				LanguageID: "vim",
+				Text:       "scriptencoding utf-8\nabnormal!\n",
+			},
+		},
+	}
+
+	symbols, err := h.symbol(uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(symbols) != 1 {
+		t.Fatalf("symbols should be only one but got: %v", symbols)
+	}
+	if symbols[0].Name != "MyFunc" {
+		t.Fatalf("name should be %q but got: %q", "MyFunc", symbols[0].Name)
+	}
+	if symbols[0].Kind != int64(symbolKindMap["function"]) {
+		t.Fatalf("kind should be %v but got: %v", symbolKindMap["function"], symbols[0].Kind)
+	}
+}


### PR DESCRIPTION
documentSymbol tried every errorformat against each output line and appended a symbol for each match, so one line matching two formats produced duplicate (and wrongly parsed) symbols. Use the first matching format like the lint scanner does. Adds a test.