### PR TITLE
Fix over-trimming of ctags search patterns in findTag

### DIFF
--- a/langserver/handle_text_document_definition.go
+++ b/langserver/handle_text_document_definition.go
@@ -59,11 +59,11 @@ func (h *langHandler) findTag(fname string, tag string) ([]Location, error) {
 				pattern := token[2]
 				hasPrefix := strings.HasPrefix(pattern, "/^")
 				if hasPrefix {
-					pattern = strings.TrimLeft(pattern, "/^")
+					pattern = strings.TrimPrefix(pattern, "/^")
 				}
 				hasSuffix := strings.HasSuffix(pattern, "$/")
 				if hasSuffix {
-					pattern = strings.TrimRight(pattern, "$/")
+					pattern = strings.TrimSuffix(pattern, "$/")
 				}
 				for i, line := range lines {
 					match := false

--- a/langserver/handle_text_document_definition_test.go
+++ b/langserver/handle_text_document_definition_test.go
@@ -37,3 +37,30 @@ func TestFindTag(t *testing.T) {
 	}
 	fmt.Println(locations)
 }
+
+func TestFindTagPatternWithDollar(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("start$\nstart extra\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tags := filepath.Join(dir, "tags")
+	if err := os.WriteFile(tags, []byte("mytag\tsrc.txt\t/^start$$/;\"\tv\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &langHandler{
+		logger:   log.New(log.Writer(), "", log.LstdFlags),
+		rootPath: dir,
+	}
+	locations, err := h.findTag(tags, "mytag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locations) != 1 {
+		t.Fatalf("locations should be only one but got: %v", locations)
+	}
+	if locations[0].Range.Start.Line != 0 {
+		t.Fatalf("range.start.line should be %v but got: %v", 0, locations[0].Range.Start.Line)
+	}
+}


### PR DESCRIPTION
TrimLeft/TrimRight treat their second argument as a character set, so `/^` and `$/` stripping also removed leading `^`/`/` and trailing `$` characters that belong to the line content, causing wrong or extra definition matches. Use TrimPrefix/TrimSuffix. Adds a test.