### PR TITLE
Handle didChange notifications with multiple content changes

### DIFF
--- a/langserver/handle_text_document_did_change.go
+++ b/langserver/handle_text_document_did_change.go
@@ -17,8 +17,11 @@ func (h *langHandler) handleTextDocumentDidChange(_ context.Context, _ *jsonrpc2
 		return nil, err
 	}
 
-	if len(params.ContentChanges) == 1 {
-		if err := h.updateFile(params.TextDocument.URI, params.ContentChanges[0].Text, &params.TextDocument.Version, eventTypeChange); err != nil {
+	if len(params.ContentChanges) > 0 {
+		// The server requests full sync, so every change carries the whole
+		// text and the last one wins.
+		text := params.ContentChanges[len(params.ContentChanges)-1].Text
+		if err := h.updateFile(params.TextDocument.URI, text, &params.TextDocument.Version, eventTypeChange); err != nil {
 			return nil, err
 		}
 	}

--- a/langserver/handle_text_document_did_change_test.go
+++ b/langserver/handle_text_document_did_change_test.go
@@ -1,0 +1,54 @@
+package langserver
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+func TestDidChangeMultipleContentChanges(t *testing.T) {
+	uri := DocumentURI("file:///foo")
+	h := &langHandler{
+		logger:       log.New(log.Writer(), "", log.LstdFlags),
+		lintDebounce: time.Millisecond,
+		request:      make(chan lintRequest, 1),
+		pendingLints: make(map[DocumentURI]eventType),
+		files: map[DocumentURI]*File{
+			uri: {
+				LanguageID: "vim",
+				Text:       "old",
+			},
+		},
+	}
+
+	params, err := json.Marshal(DidChangeTextDocumentParams{
+		TextDocument: VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: TextDocumentIdentifier{URI: uri},
+			Version:                2,
+		},
+		ContentChanges: []TextDocumentContentChangeEvent{
+			{Text: "first"},
+			{Text: "second"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := json.RawMessage(params)
+
+	req := &jsonrpc2.Request{Params: &raw}
+	if _, err := h.handleTextDocumentDidChange(context.Background(), nil, req); err != nil {
+		t.Fatal(err)
+	}
+
+	if h.files[uri].Text != "second" {
+		t.Fatalf("text should be %q but got: %q", "second", h.files[uri].Text)
+	}
+	if h.files[uri].Version != 2 {
+		t.Fatalf("version should be %v but got: %v", 2, h.files[uri].Version)
+	}
+}


### PR DESCRIPTION
didChange only applied the update when ContentChanges had exactly one element, so a client batching several full-sync changes in one notification left the document text stale. Apply the last change (full sync means last wins). Adds a test.