### PR TITLE
Fix data races between handler and lint goroutines

### DIFF
--- a/langserver/handle_initialize.go
+++ b/langserver/handle_initialize.go
@@ -28,7 +28,9 @@ func (h *langHandler) handleInitialize(_ context.Context, conn *jsonrpc2.Conn, r
 		if err != nil {
 			return nil, err
 		}
+		h.mu.Lock()
 		h.rootPath = filepath.Clean(rootPath)
+		h.mu.Unlock()
 		h.addFolder(rootPath)
 	}
 

--- a/langserver/handle_text_document_code_action.go
+++ b/langserver/handle_text_document_code_action.go
@@ -137,6 +137,7 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (any, error) 
 			if err != nil {
 				return nil, err
 			}
+			h.mu.Lock()
 			h.commands = *config.Commands
 			h.configs = *config.Languages
 			h.rootMarkers = *config.RootMarkers
@@ -144,6 +145,7 @@ func (h *langHandler) executeCommand(params *ExecuteCommandParams) (any, error) 
 			h.loglevel = config.LogLevel
 			h.lintDebounce = time.Duration(config.LintDebounce)
 			h.formatDebounce = time.Duration(config.FormatDebounce)
+			h.mu.Unlock()
 		}
 		h.logMessage(LogInfo, "Reloaded configuration file")
 		output = "OK"

--- a/langserver/handle_workspace_did_change_configuration.go
+++ b/langserver/handle_workspace_did_change_configuration.go
@@ -24,6 +24,8 @@ func (h *langHandler) handleWorkspaceDidChangeConfiguration(_ context.Context, _
 }
 
 func (h *langHandler) didChangeConfiguration(config *Config) (any, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if config.Languages != nil {
 		h.configs = *config.Languages
 	}

--- a/langserver/handle_workspace_did_change_workspace_folders.go
+++ b/langserver/handle_workspace_did_change_workspace_folders.go
@@ -21,6 +21,8 @@ func (h *langHandler) handleDidChangeWorkspaceWorkspaceFolders(_ context.Context
 }
 
 func (h *langHandler) didChangeWorkspaceFolders(params *DidChangeWorkspaceFoldersParams) (result any, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	var folders []string
 	for _, removed := range params.Event.Removed {
 		for _, folder := range h.folders {

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -283,7 +283,10 @@ func (h *langHandler) linter() {
 		go func() {
 			uriToDiagnostics, err := h.lint(ctx, lintReq.URI, lintReq.EventType)
 			if err != nil {
-				h.logger.Println(err)
+				h.mu.Lock()
+				logger := h.logger
+				h.mu.Unlock()
+				logger.Println(err)
 				return
 			}
 
@@ -292,9 +295,11 @@ func (h *langHandler) linter() {
 					diagURI = lintReq.URI
 				}
 				version := 0
-				if _, ok := h.files[lintReq.URI]; ok {
-					version = h.files[lintReq.URI].Version
+				h.mu.Lock()
+				if f, ok := h.files[lintReq.URI]; ok {
+					version = f.Version
 				}
+				h.mu.Unlock()
 				h.conn.Notify(
 					ctx,
 					"textDocument/publishDiagnostics",
@@ -346,17 +351,22 @@ func (h *langHandler) findRootPath(fname string, lang Language) string {
 	if dir := matchRootPath(fname, lang.RootMarkers); dir != "" {
 		return dir
 	}
-	if dir := matchRootPath(fname, h.rootMarkers); dir != "" {
+	h.mu.Lock()
+	rootMarkers := h.rootMarkers
+	folders := append([]string{}, h.folders...)
+	rootPath := h.rootPath
+	h.mu.Unlock()
+	if dir := matchRootPath(fname, rootMarkers); dir != "" {
 		return dir
 	}
 
-	for _, folder := range h.folders {
+	for _, folder := range folders {
 		if len(fname) > len(folder) && strings.EqualFold(fname[:len(folder)], folder) {
 			return folder
 		}
 	}
 
-	return h.rootPath
+	return rootPath
 }
 
 func isFilename(s string) bool {
@@ -369,10 +379,21 @@ func isFilename(s string) bool {
 }
 
 func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType eventType) (map[DocumentURI][]Diagnostic, error) {
+	// Snapshot the shared state under the lock: this function runs in its
+	// own goroutine and must not touch h.files or h.configs while the
+	// handler goroutine mutates them.
+	h.mu.Lock()
 	f, ok := h.files[uri]
 	if !ok {
+		h.mu.Unlock()
 		return nil, fmt.Errorf("document not found: %v", uri)
 	}
+	file := *f
+	loglevel := h.loglevel
+	logger := h.logger
+	langConfigs := append([]Language{}, h.configs[file.LanguageID]...)
+	wildcardConfigs := append([]Language{}, h.configs[wildcard]...)
+	h.mu.Unlock()
 
 	fname, err := fromURI(uri)
 	if err != nil {
@@ -381,41 +402,37 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 	fname = filepath.ToSlash(fname)
 
 	var configs []Language
-	if cfgs, ok := h.configs[f.LanguageID]; ok {
-		for _, cfg := range cfgs {
-			// if we require markers and find that they dont exist we do not add the configuration
-			if dir := matchRootPath(fname, cfg.RootMarkers); dir == "" && cfg.RequireMarker == true {
+	for _, cfg := range langConfigs {
+		// if we require markers and find that they dont exist we do not add the configuration
+		if dir := matchRootPath(fname, cfg.RootMarkers); dir == "" && cfg.RequireMarker == true {
+			continue
+		}
+		switch eventType {
+		case eventTypeOpen:
+			// if LintAfterOpen is not true, ignore didOpen
+			if !cfg.LintAfterOpen {
 				continue
 			}
-			switch eventType {
-			case eventTypeOpen:
-				// if LintAfterOpen is not true, ignore didOpen
-				if !cfg.LintAfterOpen {
-					continue
-				}
-			case eventTypeChange:
-				// if LintOnSave is true, ignore didChange
-				if cfg.LintOnSave {
-					continue
-				}
-			default:
+		case eventTypeChange:
+			// if LintOnSave is true, ignore didChange
+			if cfg.LintOnSave {
+				continue
 			}
-			if cfg.LintCommand != "" {
-				configs = append(configs, cfg)
-			}
+		default:
+		}
+		if cfg.LintCommand != "" {
+			configs = append(configs, cfg)
 		}
 	}
-	if cfgs, ok := h.configs[wildcard]; ok {
-		for _, cfg := range cfgs {
-			if cfg.LintCommand != "" {
-				configs = append(configs, cfg)
-			}
+	for _, cfg := range wildcardConfigs {
+		if cfg.LintCommand != "" {
+			configs = append(configs, cfg)
 		}
 	}
 
 	if len(configs) == 0 {
-		if h.loglevel >= 1 {
-			h.logger.Printf("lint for LanguageID not supported: %v", f.LanguageID)
+		if loglevel >= 1 {
+			logger.Printf("lint for LanguageID not supported: %v", file.LanguageID)
 		}
 		return map[DocumentURI][]Diagnostic{}, nil
 	}
@@ -427,11 +444,13 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 	for i, config := range configs {
 		// To publish empty diagnostics when errors are fixed
 		if config.LintWorkspace {
-			for lastPublishedURI := range h.lastPublishedURIs[f.LanguageID] {
+			h.mu.Lock()
+			for lastPublishedURI := range h.lastPublishedURIs[file.LanguageID] {
 				if _, ok := uriToDiagnostics[lastPublishedURI]; !ok {
 					uriToDiagnostics[lastPublishedURI] = []Diagnostic{}
 				}
 			}
+			h.mu.Unlock()
 		}
 
 		if config.LintCommand == "" {
@@ -464,7 +483,7 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 		cmd.Dir = rootPath
 		cmd.Env = append(os.Environ(), config.Env...)
 		if config.LintStdin {
-			cmd.Stdin = strings.NewReader(f.Text)
+			cmd.Stdin = strings.NewReader(file.Text)
 		}
 		b, err := cmd.CombinedOutput()
 		if err != nil {
@@ -481,8 +500,8 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 			h.logMessage(LogError, "command `"+command+"` exit with zero. probably you forgot to specify `lint-ignore-exit-code: true`.")
 			continue
 		}
-		if h.loglevel >= 3 {
-			h.logger.Println(command+":", string(b))
+		if loglevel >= 3 {
+			logger.Println(command+":", string(b))
 		}
 		var source *string
 		if config.LintSource != "" {
@@ -531,7 +550,7 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 			if entry.Col == 0 {
 				entry.Col = 1 // entry.Col == 0 indicates the whole line without column, set to 1 because it is subtracted later
 			} else {
-				word = f.WordAt(Position{Line: entry.Lnum - 1 - config.LintOffset, Character: entry.Col - 1})
+				word = file.WordAt(Position{Line: entry.Lnum - 1 - config.LintOffset, Character: entry.Col - 1})
 			}
 
 			// we allow the config to provide a mapping between LSP types E,W,I,N and whatever categories the linter has
@@ -595,7 +614,9 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 	// Update state here as no possibility of cancelation
 	for _, config := range configs {
 		if config.LintWorkspace {
-			h.lastPublishedURIs[f.LanguageID] = publishedURIs
+			h.mu.Lock()
+			h.lastPublishedURIs[file.LanguageID] = publishedURIs
+			h.mu.Unlock()
 			break
 		}
 	}
@@ -611,7 +632,9 @@ func itoaPtrIfNotZero(n int) *string {
 }
 
 func (h *langHandler) closeFile(uri DocumentURI) error {
+	h.mu.Lock()
 	delete(h.files, uri)
+	h.mu.Unlock()
 	return nil
 }
 
@@ -626,19 +649,24 @@ func (h *langHandler) openFile(uri DocumentURI, languageID string, version int) 
 		LanguageID: languageID,
 		Version:    version,
 	}
+	h.mu.Lock()
 	h.files[uri] = f
+	h.mu.Unlock()
 	return nil
 }
 
 func (h *langHandler) updateFile(uri DocumentURI, text string, version *int, eventType eventType) error {
+	h.mu.Lock()
 	f, ok := h.files[uri]
 	if !ok {
+		h.mu.Unlock()
 		return fmt.Errorf("document not found: %v", uri)
 	}
 	f.Text = text
 	if version != nil {
 		f.Version = *version
 	}
+	h.mu.Unlock()
 
 	h.lintRequest(uri, eventType)
 	return nil
@@ -658,6 +686,8 @@ func (h *langHandler) configFor(uri DocumentURI) []Language {
 
 func (h *langHandler) addFolder(folder string) {
 	folder = filepath.Clean(folder)
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	found := false
 	for _, cur := range h.folders {
 		if cur == folder {

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -31,6 +32,58 @@ func TestLintRequestDebounceKeepsAllURIs(t *testing.T) {
 			t.Fatalf("timed out waiting for lint requests, got: %v", got)
 		}
 	}
+}
+
+func TestLintConcurrentFileUpdate(t *testing.T) {
+	base, _ := os.Getwd()
+	file := filepath.Join(base, "foo")
+	uri := toURI(file)
+
+	h := &langHandler{
+		logger:            log.New(log.Writer(), "", log.LstdFlags),
+		rootPath:          base,
+		lintDebounce:      100 * time.Millisecond,
+		request:           make(chan lintRequest, 10),
+		pendingLints:      make(map[DocumentURI]eventType),
+		lastPublishedURIs: make(map[string]map[DocumentURI]struct{}),
+		configs: map[string][]Language{
+			"vim": {
+				{
+					LintCommand:        `echo ` + file + `:2:No it is normal!`,
+					LintIgnoreExitCode: true,
+					LintStdin:          true,
+				},
+			},
+		},
+		files: map[DocumentURI]*File{
+			uri: {
+				LanguageID: "vim",
+				Text:       "scriptencoding utf-8\nabnormal!\n",
+			},
+		},
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = h.updateFile(uri, strings.Repeat("x", i%64)+"\n", nil, eventTypeChange)
+		}
+	}()
+	for i := 0; i < 5; i++ {
+		if _, err := h.lint(context.Background(), uri, eventTypeChange); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	wg.Wait()
 }
 
 func TestLintNoLinter(t *testing.T) {


### PR DESCRIPTION
lint() runs in its own goroutine but read h.files, File.Text/Version and h.configs while the handler goroutine mutates them via didChange/didOpen/didClose and configuration reloads, which is a data race (torn string reads can crash). Snapshot the file and configs under h.mu at the start of lint, and guard the writers (updateFile/openFile/closeFile, workspace folders, configuration reload) plus lastPublishedURIs and findRootPath state with the same mutex. Adds a concurrent regression test that fails under -race on the old code.