### PR TITLE
Make -loglevel flag actually take effect

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,17 @@ func main() {
 	if logfile == "" {
 		logfile = config.LogFile
 	}
-	if config.LogLevel > 0 {
+	loglevelSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "loglevel" {
+			loglevelSet = true
+		}
+	})
+	if loglevelSet {
+		// An explicitly passed -loglevel takes precedence over the
+		// configuration file.
+		config.LogLevel = loglevel
+	} else if config.LogLevel > 0 {
 		loglevel = config.LogLevel
 	}
 


### PR DESCRIPTION
The -loglevel flag value was never written back to config.LogLevel, so the handler's verbosity came only from the configuration file and the flag was silently ignored. Apply the flag when explicitly passed (flag wins over config, matching -logfile semantics); behavior without the flag is unchanged.