### PR TITLE
Fix panic when a debounced lint fires after shutdown

### DIFF
--- a/langserver/handle_shutdown.go
+++ b/langserver/handle_shutdown.go
@@ -7,10 +7,20 @@ import (
 )
 
 func (h *langHandler) handleShutdown(_ context.Context, conn *jsonrpc2.Conn, _ *jsonrpc2.Request) (result any, err error) {
+	h.shutdown()
+	return nil, conn.Close()
+}
+
+func (h *langHandler) shutdown() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.isShutdown {
+		return
+	}
+	h.isShutdown = true
 	if h.lintTimer != nil {
 		h.lintTimer.Stop()
+		h.lintTimer = nil
 	}
-
 	close(h.request)
-	return nil, conn.Close()
 }

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -140,6 +140,7 @@ type langHandler struct {
 	lintDebounce      time.Duration
 	lintTimer         *time.Timer
 	pendingLints      map[DocumentURI]eventType
+	isShutdown        bool
 	formatDebounce    time.Duration
 	formatTimer       *time.Timer
 	conn              *jsonrpc2.Conn
@@ -236,20 +237,27 @@ func toURI(path string) DocumentURI {
 func (h *langHandler) lintRequest(uri DocumentURI, event eventType) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.isShutdown {
+		return
+	}
 	h.pendingLints[uri] = event
 	if h.lintTimer != nil {
 		h.lintTimer.Reset(h.lintDebounce)
 		return
 	}
 	h.lintTimer = time.AfterFunc(h.lintDebounce, func() {
+		// Sending while holding the lock serializes this callback with
+		// shutdown(), which closes h.request under the same lock.
 		h.mu.Lock()
+		defer h.mu.Unlock()
 		h.lintTimer = nil
-		pending := h.pendingLints
-		h.pendingLints = make(map[DocumentURI]eventType)
-		h.mu.Unlock()
-		for pendingURI, pendingEventType := range pending {
+		if h.isShutdown {
+			return
+		}
+		for pendingURI, pendingEventType := range h.pendingLints {
 			h.request <- lintRequest{URI: pendingURI, EventType: pendingEventType}
 		}
+		h.pendingLints = make(map[DocumentURI]eventType)
 	})
 }
 

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -104,6 +104,10 @@ func TestShutdownWithPendingLintDoesNotPanic(t *testing.T) {
 	// New lint requests after shutdown must be ignored.
 	h.lintRequest("file:///b", eventTypeChange)
 	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := <-h.request; ok {
+		t.Fatal("no lint request should be sent after shutdown")
+	}
 }
 
 func TestLintNoLinter(t *testing.T) {

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -86,6 +86,26 @@ func TestLintConcurrentFileUpdate(t *testing.T) {
 	wg.Wait()
 }
 
+func TestShutdownWithPendingLintDoesNotPanic(t *testing.T) {
+	h := &langHandler{
+		lintDebounce: 10 * time.Millisecond,
+		request:      make(chan lintRequest),
+		pendingLints: make(map[DocumentURI]eventType),
+	}
+
+	h.lintRequest("file:///a", eventTypeChange)
+	h.shutdown()
+	// A second shutdown must not panic either.
+	h.shutdown()
+	// Give the debounce timer a chance to fire; sending on the closed
+	// channel would panic and crash the test.
+	time.Sleep(50 * time.Millisecond)
+
+	// New lint requests after shutdown must be ignored.
+	h.lintRequest("file:///b", eventTypeChange)
+	time.Sleep(50 * time.Millisecond)
+}
+
 func TestLintNoLinter(t *testing.T) {
 	h := &langHandler{
 		logger:  log.New(log.Writer(), "", log.LstdFlags),


### PR DESCRIPTION
shutdown closed the request channel while a pending debounce timer could still fire and send on it, panicking with "send on closed channel". A second shutdown request also panicked on double close. Guard the timer callback, lintRequest and close with the mutex and a shutdown flag. Adds a test.