### PR TITLE
Ignore unknown notifications instead of returning an error

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -748,6 +748,16 @@ func (h *langHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 		return h.handleWorkspaceWorkspaceFolders(ctx, conn, req)
 	}
 
+	// LSP requires servers to ignore notifications they do not handle
+	// (e.g. window/progress, $/setTrace) instead of responding with an
+	// error.
+	if req.Notif {
+		if h.loglevel >= 1 {
+			h.logger.Printf("notification not supported: %s", req.Method)
+		}
+		return nil, nil
+	}
+
 	return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: fmt.Sprintf("method not supported: %s", req.Method)}
 }
 

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/sourcegraph/jsonrpc2"
 )
 
 func TestLintRequestDebounceKeepsAllURIs(t *testing.T) {
@@ -84,6 +86,24 @@ func TestLintConcurrentFileUpdate(t *testing.T) {
 	}
 	close(stop)
 	wg.Wait()
+}
+
+func TestUnknownMethods(t *testing.T) {
+	h := &langHandler{
+		logger: log.New(log.Writer(), "", log.LstdFlags),
+	}
+
+	// Unknown notifications must be ignored per the LSP spec.
+	if _, err := h.handle(context.Background(), nil, &jsonrpc2.Request{Method: "window/progress", Notif: true}); err != nil {
+		t.Fatalf("unknown notification should be ignored but got: %v", err)
+	}
+
+	// Unknown requests must still return MethodNotFound.
+	_, err := h.handle(context.Background(), nil, &jsonrpc2.Request{Method: "textDocument/rename"})
+	var rpcErr *jsonrpc2.Error
+	if !errors.As(err, &rpcErr) || rpcErr.Code != jsonrpc2.CodeMethodNotFound {
+		t.Fatalf("unknown request should return MethodNotFound but got: %v", err)
+	}
 }
 
 func TestShutdownWithPendingLintDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
The LSP spec requires servers to drop notifications they do not handle, but efm replied with MethodNotFound, which clients like neovim print as recurring stderr errors (e.g. window/progress, $/setTrace). Ignore unknown notifications (logged at loglevel >= 1) while keeping MethodNotFound for unknown requests. Fixes #160. Adds a test.