### PR TITLE
Support %e and %k for diagnostic end positions

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -547,8 +547,13 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 			// entry.Col is expected to be one based, if the linter returns zero based we
 			// have the ability to add an offset here.
 			// We only add the offset if the linter reports entry.Col > 0 because 0 means the whole line
-			if config.LintOffsetColumns > 0 && entry.Col > 0 {
-				entry.Col = entry.Col + config.LintOffsetColumns
+			if config.LintOffsetColumns > 0 {
+				if entry.Col > 0 {
+					entry.Col = entry.Col + config.LintOffsetColumns
+				}
+				if entry.EndCol > 0 {
+					entry.EndCol = entry.EndCol + config.LintOffsetColumns
+				}
 			}
 
 			if entry.Lnum == 0 {
@@ -606,10 +611,23 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 			if config.LintWorkspace {
 				publishedURIs[diagURI] = struct{}{}
 			}
+			start := Position{Line: entry.Lnum - 1 - config.LintOffset, Character: entry.Col - 1}
+			end := Position{Line: start.Line, Character: entry.Col - 1 + len([]rune(word))}
+			// %e (end line) and %k (end column, exclusive like eslint's
+			// endColumn) take precedence over the word-based guess.
+			if entry.EndLnum > 0 {
+				end.Line = entry.EndLnum - 1 - config.LintOffset
+			}
+			if entry.EndCol > 0 {
+				end.Character = entry.EndCol - 1
+			}
+			if end.Line < start.Line || (end.Line == start.Line && end.Character < start.Character) {
+				end = start
+			}
 			uriToDiagnostics[diagURI] = append(uriToDiagnostics[diagURI], Diagnostic{
 				Range: Range{
-					Start: Position{Line: entry.Lnum - 1 - config.LintOffset, Character: entry.Col - 1},
-					End:   Position{Line: entry.Lnum - 1 - config.LintOffset, Character: entry.Col - 1 + len([]rune(word))},
+					Start: start,
+					End:   end,
 				},
 				Code:     itoaPtrIfNotZero(entry.Nr),
 				Message:  prefix + entry.Text,

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -359,6 +359,48 @@ func TestLintOffsetColumnsNonZero(t *testing.T) {
 	}
 }
 
+func TestLintEndPositions(t *testing.T) {
+	base, _ := os.Getwd()
+	file := filepath.Join(base, "foo")
+	uri := toURI(file)
+
+	h := &langHandler{
+		logger:   log.New(log.Writer(), "", log.LstdFlags),
+		rootPath: base,
+		configs: map[string][]Language{
+			wildcard: {
+				{
+					LintCommand:        `echo ` + file + `:2:1:3:6:msg`,
+					LintFormats:        []string{"%f:%l:%c:%e:%k:%m"},
+					LintIgnoreExitCode: true,
+					LintStdin:          true,
+				},
+			},
+		},
+		files: map[DocumentURI]*File{
+			uri: {
+				LanguageID: "vim",
+				Text:       "scriptencoding utf-8\nabnormal!\nabnormal!\n",
+			},
+		},
+	}
+
+	uriToDiag, err := h.lint(context.Background(), uri, eventTypeChange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := uriToDiag[uri]
+	if len(d) != 1 {
+		t.Fatal("diagnostics should be only one")
+	}
+	if d[0].Range.Start.Line != 1 || d[0].Range.Start.Character != 0 {
+		t.Fatalf("range.start should be {1 0} but got: %v", d[0].Range.Start)
+	}
+	if d[0].Range.End.Line != 2 || d[0].Range.End.Character != 5 {
+		t.Fatalf("range.end should be {2 5} but got: %v", d[0].Range.End)
+	}
+}
+
 func TestLintCategoryMap(t *testing.T) {
 	base, _ := os.Getwd()
 	file := filepath.Join(base, "foo")


### PR DESCRIPTION
Diagnostic ranges always ended on the start line at start column + word length, so `%e` (end line) and `%k` (end column) in lint-formats were parsed but ignored. Use them for the range end when present (end column treated as exclusive, matching eslint's endColumn), honoring lint-offset/lint-offset-columns, with a sanity fallback when the parsed end precedes the start. Fixes #287. Adds a test.