### PR TITLE
Fix formatting edits for CRLF files and files without trailing newline

### DIFF
--- a/langserver/diff.go
+++ b/langserver/diff.go
@@ -8,6 +8,7 @@ package langserver
 
 import (
 	"strings"
+	"unicode/utf16"
 )
 
 // OpKind is used to denote the type of operation a line represents.
@@ -50,6 +51,24 @@ func ComputeEdits(_ DocumentURI, before, after string) []TextEdit {
 					},
 					NewText: content,
 				})
+			}
+		}
+	}
+
+	// When the document does not end with a newline, the line-based
+	// operations above can reference the line one past the last one, which
+	// does not exist. Clamp those positions to the end of the last line so
+	// clients are not left to guess how to apply out-of-range edits.
+	if before != "" && !strings.HasSuffix(before, "\n") {
+		lines := splitLines(before)
+		lastLine := len(lines) - 1
+		lastChar := len(utf16.Encode([]rune(lines[lastLine])))
+		for i := range edits {
+			if edits[i].Range.Start.Line > lastLine {
+				edits[i].Range.Start = Position{Line: lastLine, Character: lastChar}
+			}
+			if edits[i].Range.End.Line > lastLine {
+				edits[i].Range.End = Position{Line: lastLine, Character: lastChar}
 			}
 		}
 	}

--- a/langserver/diff_test.go
+++ b/langserver/diff_test.go
@@ -1,0 +1,78 @@
+package langserver
+
+import (
+	"strings"
+	"testing"
+)
+
+// applyEdits applies line/character based TextEdits to a document the way an
+// LSP client would, for verifying that the produced edits are valid and give
+// the expected result.
+func applyEdits(t *testing.T, text string, edits []TextEdit) string {
+	t.Helper()
+	lines := strings.SplitAfter(text, "\n")
+	offset := func(p Position) int {
+		if p.Line >= len(lines) {
+			if p.Line > len(lines) || p.Character != 0 {
+				t.Fatalf("position %v is out of bounds for %q", p, text)
+			}
+			return len(text)
+		}
+		o := 0
+		for i := 0; i < p.Line; i++ {
+			o += len(lines[i])
+		}
+		line := lines[p.Line]
+		if p.Character > len(strings.TrimSuffix(line, "\n")) {
+			t.Fatalf("position %v is out of bounds for %q", p, text)
+		}
+		return o + p.Character
+	}
+	// Apply in reverse so earlier offsets stay valid.
+	for i := len(edits) - 1; i >= 0; i-- {
+		start := offset(edits[i].Range.Start)
+		end := offset(edits[i].Range.End)
+		text = text[:start] + edits[i].NewText + text[end:]
+	}
+	return text
+}
+
+func TestComputeEditsNoTrailingNewline(t *testing.T) {
+	before := "export const test = () => {}"
+	after := "export const test = () => {};\n"
+
+	edits := ComputeEdits("file:///foo", before, after)
+	for _, e := range edits {
+		if e.Range.Start.Line > 0 || e.Range.End.Line > 0 {
+			t.Fatalf("edit references a line past the end of the document: %+v", e)
+		}
+	}
+	if got := applyEdits(t, before, edits); got != after {
+		t.Fatalf("applying edits should produce %q but got: %q", after, got)
+	}
+}
+
+func TestComputeEditsNoTrailingNewlineMultiline(t *testing.T) {
+	before := "aaa\nbbb"
+	after := "aaa\nccc\nddd\n"
+
+	edits := ComputeEdits("file:///foo", before, after)
+	for _, e := range edits {
+		if e.Range.Start.Line > 1 || e.Range.End.Line > 1 {
+			t.Fatalf("edit references a line past the end of the document: %+v", e)
+		}
+	}
+	if got := applyEdits(t, before, edits); got != after {
+		t.Fatalf("applying edits should produce %q but got: %q", after, got)
+	}
+}
+
+func TestComputeEditsTrailingNewline(t *testing.T) {
+	before := "foo \nbar\n"
+	after := "foo\nbar\n"
+
+	edits := ComputeEdits("file:///foo", before, after)
+	if got := applyEdits(t, before, edits); got != after {
+		t.Fatalf("applying edits should produce %q but got: %q", after, got)
+	}
+}

--- a/langserver/handle_text_document_formatting.go
+++ b/langserver/handle_text_document_formatting.go
@@ -214,6 +214,13 @@ Configs:
 		text = strings.Replace(string(b), "\r", "", -1)
 	}
 
+	// The formatter output was normalized to LF above; when the original
+	// document uses CRLF, restore it so the diff is computed against
+	// matching line endings instead of treating every line as changed.
+	if strings.Contains(originalText, "\r\n") {
+		text = strings.Replace(text, "\n", "\r\n", -1)
+	}
+
 	if text == originalText || text == "" {
 		// probably it was formatted in place
 		return nil, nil

--- a/langserver/handle_text_document_formatting_test.go
+++ b/langserver/handle_text_document_formatting_test.go
@@ -44,3 +44,38 @@ func TestFormattingRequireRootMatcher(t *testing.T) {
 		t.Fatal("text edits should be zero as we have no root marker for the language but require one", d)
 	}
 }
+
+func TestFormattingCRLF(t *testing.T) {
+	base, _ := os.Getwd()
+	file := filepath.Join(base, "foo")
+	uri := toURI(file)
+
+	original := "a\r\nb\r\n"
+	h := &langHandler{
+		logger:   log.New(log.Writer(), "", log.LstdFlags),
+		rootPath: base,
+		configs: map[string][]Language{
+			"vim": {
+				{
+					FormatCommand: `echo a`,
+					FormatStdin:   true,
+				},
+			},
+		},
+		files: map[DocumentURI]*File{
+			uri: {
+				LanguageID: "vim",
+				Text:       original,
+			},
+		},
+	}
+
+	rng := Range{Position{-1, -1}, Position{-1, -1}}
+	edits, err := h.rangeFormatting(uri, rng, FormattingOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := applyEdits(t, original, edits); got != "a\r\n" {
+		t.Fatalf("applying edits should produce %q but got: %q", "a\r\n", got)
+	}
+}


### PR DESCRIPTION
Two formatting bugs around line endings:

- Formatter output had all \r stripped but was then diffed against the original CRLF text, so on CRLF files every line appeared changed and even a no-op format produced whole-file edits with mixed line endings. Restore CRLF in the output before diffing when the original uses it.
- When the document does not end with a newline, ComputeEdits emitted ranges referencing the nonexistent line past the end; clients clamp such out-of-spec positions inconsistently, producing the stray blank lines reported in #241/#181. Clamp those positions to the end of the last line.

Adds tests that verify the produced edits apply cleanly. Fixes #241. Fixes #181.