### PR TITLE
Publish same-file diagnostics under the client's URI

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -597,15 +597,17 @@ func (h *langHandler) lint(ctx context.Context, uri DocumentURI, eventType event
 					diagURI = toURI(filepath.Join(rootPath, entry.Filename))
 				}
 			}
+			diagFname, _ := fromURI(diagURI)
+			sameFile := diagFname == fname
 			if runtime.GOOS == "windows" {
-				if strings.ToLower(string(diagURI)) != strings.ToLower(string(uri)) && !config.LintWorkspace {
-					continue
-				}
-			} else {
-				diagFname, _ := fromURI(diagURI)
-				if diagFname != fname && !config.LintWorkspace {
-					continue
-				}
+				sameFile = strings.EqualFold(diagFname, fname)
+			}
+			if sameFile {
+				// Reuse the client's URI so its escaping (e.g. %5B for
+				// "[") matches what the client expects.
+				diagURI = uri
+			} else if !config.LintWorkspace {
+				continue
 			}
 
 			if config.LintWorkspace {

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -421,6 +421,49 @@ func TestLintEndPositions(t *testing.T) {
 	}
 }
 
+func TestLintClientURIEscaping(t *testing.T) {
+	base, _ := os.Getwd()
+	file := filepath.ToSlash(filepath.Join(base, "[id]", "foo"))
+
+	// Clients may percent-encode URIs differently from toURI (e.g. VSCode
+	// sends c%3A for the drive colon); diagnostics must still be published
+	// under the URI the client uses. "%6f%6f" decodes to "oo".
+	clientURI := DocumentURI(strings.Replace(string(toURI(file)), "foo", "f%6f%6f", 1))
+
+	h := &langHandler{
+		logger:   log.New(log.Writer(), "", log.LstdFlags),
+		rootPath: base,
+		configs: map[string][]Language{
+			wildcard: {
+				{
+					LintCommand:        `echo ` + file + `:2:1:msg`,
+					LintFormats:        []string{"%f:%l:%c:%m"},
+					LintIgnoreExitCode: true,
+					LintStdin:          true,
+				},
+			},
+		},
+		files: map[DocumentURI]*File{
+			clientURI: {
+				LanguageID: "vim",
+				Text:       "scriptencoding utf-8\nabnormal!\n",
+			},
+		},
+	}
+
+	uriToDiag, err := h.lint(context.Background(), clientURI, eventTypeChange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, ok := uriToDiag[clientURI]
+	if !ok {
+		t.Fatalf("diagnostics should be published with the client's URI %q but got: %v", clientURI, uriToDiag)
+	}
+	if len(d) != 1 {
+		t.Fatalf("diagnostics should be only one but got: %v", d)
+	}
+}
+
 func TestLintCategoryMap(t *testing.T) {
 	base, _ := os.Getwd()
 	file := filepath.Join(base, "foo")


### PR DESCRIPTION
When a linter reports the file being linted, efm rebuilt the URI with toURI, whose percent-encoding can differ from the client's (e.g. VSCode sends c%3A for the drive colon). Clients match diagnostics by exact URI, so such diagnostics were silently dropped. Compare decoded paths (case-insensitive on Windows) and reuse the client's URI when the diagnostic is for the linted file. Likely fixes #294. Adds a test.